### PR TITLE
Fix: Added undefined check when starting pool

### DIFF
--- a/lib/InstancePool.js
+++ b/lib/InstancePool.js
@@ -89,7 +89,7 @@ InstancePool.removeFromPool = function(instanceId, done) {
 InstancePool.prototype.initialize = function(server, done) {
   // Restart existing termination schedules (TTL's)
   this.getPoolInstancesByFilters(undefined, function(instances) {
-    if (instances === undefined ) {
+    if (instances === undefined) {
       if (done) { done(); }
       return;
     }


### PR DESCRIPTION
Previously failed if no instances had 'Termination Time' tag. Will now start regardless (as is expected).
