### PR TITLE
Fix travis configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
   - "0.10"
+branches:
+  only:
+  - master


### PR DESCRIPTION
The default travis configuration results in multiple builds when
branches are made to the main project. This change causes builds
to only run for pull requests and merges to master.
