### PR TITLE
Use 'us-east-1' as default AWS region.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,6 +27,9 @@ module.exports = function(grunt) {
   , mochaIstanbul: {
       coverage: {
         src: 'test'
+      , options: {
+          recursive: true
+        }
       }
     }
   });

--- a/lib/InstancePool.js
+++ b/lib/InstancePool.js
@@ -1,9 +1,8 @@
 var request = require('request');
+
 var AWS = require('aws-sdk');
-var ec2 = new AWS.EC2({
-  apiVersion: '2014-10-01'
-, region: 'us-west-2'
-});
+var AwsHelper = require('./helpers/aws');
+var ec2 = AwsHelper.createEc2Client();
 
 var Instances = require('./Instances');
 var Tags = require('./Tags');

--- a/lib/Instances.js
+++ b/lib/Instances.js
@@ -1,9 +1,7 @@
 var request = require('request');
-var AWS = require('aws-sdk');
-var ec2 = new AWS.EC2({
-  apiVersion: '2014-10-01'
-, region: 'us-west-2'
-});
+
+var AwsHelper = require('./helpers/aws');
+var ec2 = AwsHelper.createEc2Client();
 
 var Tags = require('./Tags');
 

--- a/lib/Tags.js
+++ b/lib/Tags.js
@@ -1,8 +1,5 @@
-var AWS = require('aws-sdk');
-var ec2 = new AWS.EC2({
-  apiVersion: '2014-10-01'
-, region: 'us-west-2'
-});
+var AwsHelper = require('./helpers/aws');
+var ec2 = AwsHelper.createEc2Client();
 
 var Instances = require('./Instances');
 

--- a/lib/helpers/aws.js
+++ b/lib/helpers/aws.js
@@ -1,0 +1,14 @@
+var AWS       = require('aws-sdk');
+var AwsHelper = module.exports = {};
+
+AwsHelper.API_VERSION    = '2015-04-15';
+AwsHelper.DEFAULT_REGION = 'us-east-1';
+
+AwsHelper.createEc2Client = function() {
+  return new AWS.EC2({
+    apiVersion : AwsHelper.API_VERSION
+  , region     : process.env.AWS_REGION || AwsHelper.DEFAULT_REGION
+  });
+};
+
+Object.freeze(AwsHelper);

--- a/lib/routes/instances.js
+++ b/lib/routes/instances.js
@@ -1,10 +1,5 @@
 var Joi = require('joi');
 var Boom = require('boom');
-var AWS = require('aws-sdk');
-var ec2 = new AWS.EC2({
-  apiVersion: '2014-10-01'
-, region: 'us-west-2'
-});
 
 var InstancePool = require('./../../lib/InstancePool');
 var Instances = require('./../../lib/Instances');
@@ -66,7 +61,7 @@ module.exports = [
         switch (state) {
           case 'stopped':
             var params = { InstanceIds: [instanceId] };
-            ec2.stopInstances(params, function(error, data) {
+            Instances.ec2.stopInstances(params, function(error, data) {
               if (error) {
                 request.log('info', error, error.stack);
                 reply(error).code(400);
@@ -78,7 +73,7 @@ module.exports = [
             break;
           case 'running':
             params = { InstanceIds: [instanceId] };
-            ec2.startInstances(params, function(error, data) {
+            Instances.ec2.startInstances(params, function(error, data) {
               if (error) {
                 request.log('info', error, error.stack);
                 reply(error).code(400);
@@ -90,7 +85,7 @@ module.exports = [
             break;
           case 'terminated':
             params = { InstanceIds: [instanceId] };
-            ec2.terminateInstances(params, function(error, data) {
+            Instances.ec2.terminateInstances(params, function(error, data) {
               if (error) {
                 request.log('info', error, error.stack);
                 reply(error).code(400);
@@ -114,7 +109,7 @@ module.exports = [
           InstanceIds: [encodeURIComponent(request.params.resourceId)]
         };
       }
-      ec2.describeInstances(params, function(err, data) {
+      Instances.ec2.describeInstances(params, function(err, data) {
         if (err) {
           reply(Boom.badRequest(err));
         } else {

--- a/lib/routes/tags.js
+++ b/lib/routes/tags.js
@@ -1,10 +1,5 @@
 var Joi = require('joi');
 var Boom = require('boom');
-var AWS = require('aws-sdk');
-var ec2 = new AWS.EC2({
-  apiVersion: '2014-10-01'
-, region: 'us-west-2'
-});
 
 var InstancePool = require('./../../lib/InstancePool');
 var Instances = require('./../../lib/Instances');

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "text-table": "^0.2.0"
   },
   "devDependencies": {
+    "apparition": "^1.0.0",
     "touch": "0.0.3"
   }
 }

--- a/test/helpers/aws_spec.js
+++ b/test/helpers/aws_spec.js
@@ -1,0 +1,67 @@
+var AwsHelper   = require('../../lib/helpers/aws');
+var Environment = require('apparition').Environment;
+
+var expect = require('chai').expect;
+
+describe('The AWS helper', function() {
+  function itIsReadOnly(object, property) {
+    it('is read-only', function() {
+      var originalValue = object[property];
+
+      object[property] = 'foo';
+
+      expect(object[property]).to.equal(originalValue);
+    });
+  }
+
+  describe('API version', function() {
+    it('is exported', function() {
+      expect(AwsHelper).to.have.property('API_VERSION', '2015-04-15');
+    });
+
+    itIsReadOnly(AwsHelper, 'API_VERSION');
+  });
+
+  describe('default region', function() {
+    it('is exported', function() {
+      expect(AwsHelper).to.have.property('DEFAULT_REGION', 'us-east-1');
+    });
+
+    itIsReadOnly(AwsHelper, 'DEFAULT_REGION');
+  });
+
+  describe('creating a new EC2 client', function() {
+    var client;
+
+    before(function() {
+      client = AwsHelper.createEc2Client();
+    });
+
+    it('uses the API version from the helper', function() {
+      expect(client.config.apiVersion).to.equal(AwsHelper.API_VERSION);
+    });
+
+    it('uses the default region', function() {
+      expect(client.config.region).to.equal(AwsHelper.DEFAULT_REGION);
+    });
+
+    describe('with a custom region', function() {
+      var environment = new Environment();
+      var region      = 'us-west-1';
+      var client;
+
+      before(function() {
+        environment.set('AWS_REGION', region);
+        client = AwsHelper.createEc2Client();
+      });
+
+      after(function() {
+        environment.restore();
+      });
+
+      it('uses the specified region', function() {
+        expect(client.config.region).to.equal(region);
+      });
+    });
+  });
+});

--- a/test/instance_pool_spec.js
+++ b/test/instance_pool_spec.js
@@ -4,10 +4,8 @@ const sinon = require('sinon');
 const should = require('chai').should();
 
 var AWS = require('aws-sdk');
-var ec2 = new AWS.EC2({
-  apiVersion: '2014-10-01'
-, region: 'us-west-2'
-});
+var AwsHelper = require('../lib/helpers/aws');
+var ec2 = AwsHelper.createEc2Client();
 
 var InstancePool = require('./../lib/InstancePool');
 var Helper = require('./test_helper');
@@ -41,6 +39,12 @@ describe('InstancePool', function() {
 
     after(function() {
       AWS.config.credentials = originalCreds;
+    });
+
+    it('uses the default AWS client configuration', function() {
+      var pool = new InstancePool();
+      expect(pool.ec2.config.apiVersion).to.equal(AwsHelper.API_VERSION);
+      expect(pool.ec2.config.region).to.equal(AwsHelper.DEFAULT_REGION);
     });
 
     it ('defaults to the NaiveStrategy', function(done) {
@@ -157,7 +161,6 @@ describe('InstancePool', function() {
           callback(instanceId);
         }
         var InstancePool = proxyquire('./../lib/InstancePool', { './Tags': tagsStub });
-        InstancePool.ec2 = ec2;
 
         done();
       });

--- a/test/pooling_strategies/naive_strategy_spec.js
+++ b/test/pooling_strategies/naive_strategy_spec.js
@@ -3,13 +3,13 @@ const should = require('chai').should();
 
 const NaiveStrategy = require('./../../lib/poolingStrategies/NaiveStrategy');
 
-var strat;
-
-beforeEach(function(done) {
-  strat = new NaiveStrategy();
-})
-
 describe('NaiveStrategy', function() {
+  var strat;
+
+  beforeEach(function() {
+    strat = new NaiveStrategy();
+  })
+
   describe('.getRequiredInstances', function() {
     it('should return an array of required instances', function(done) {
       done();


### PR DESCRIPTION
This change changes the default AWS region from 'us-west-2' to
'us-east-1'. It also provides the ability to override the default
region configuration with the 'AWS_REGION' environment variable.

Fixes #29.
