### PR TITLE
Use a custom security group

### DIFF
--- a/lib/plugins/rest.js
+++ b/lib/plugins/rest.js
@@ -45,12 +45,16 @@ exports.register = function (server, options, next) {
 			var result;
 			var ami  = request.payload.ami;
 			var type = request.payload.type;
-			var securityGroup = request.payload.securityGroup || "service-maker";
+
+			var instanceOptions = {
+				createSecurityGroup   : request.payload.createSecurityGroup,
+				existingSecurityGroup : request.payload.existingSecurityGroup
+			};
 
 			instances.createInstance(ami, type)
 			.then(function (instance) {
 				result = instance;
-				return awsAdapter.runInstances(instance, securityGroup);
+				return awsAdapter.runInstances(instance, instanceOptions);
 			})
 			.then(function (instance) {
 				reply(instance).created("/v1/instances/" + instance.id);

--- a/lib/services/awsAdapter.js
+++ b/lib/services/awsAdapter.js
@@ -42,18 +42,13 @@ function AWSAdapter (options) {
 		throw new Error(JoiValidator.error.message);
 	}
 
-	this.runInstances = function (instance, securityGroup) {
+	this.runInstances = function (instance, instanceOptions) {
 		var self   = this;
 
 		var result = _.clone(instance);
 
-		var securityGroupParams = {
-			Description : "A security group created by service-maker.",
-			GroupName   : securityGroup
-		};
-
-		return self.createSecurityGroup(securityGroupParams)
-		.then(function () {
+		return self.createSecurityGroup(instanceOptions.createSecurityGroup, instanceOptions.existingSecurityGroup)
+		.then(function (securityGroup) {
 			var params = {
 				ImageId        : instance.ami,
 				InstanceType   : instance.type,
@@ -208,36 +203,62 @@ function AWSAdapter (options) {
 
 	};
 
-	this.createSecurityGroup = function (params) {
-		var groupName = params.GroupName;
+	this.createSecurityGroup = function (create, existing) {
 
-		return ec2.createSecurityGroupAsync(params)
-		.then(function (data) {
-			var params = {
-				GroupName     : groupName,
-				GroupId       : data.GroupId,
-				IpPermissions : [ {
-					FromPort   : 22,
-					IpProtocol : "tcp",
-					ToPort     : 22,
-					IpRanges   : [ { CidrIp : "0.0.0.0/0" } ]
-				} ]
+		var securityGroupParams;
+
+		if (create === undefined) {
+			if (existing === undefined) {
+				//The default service maker security group.
+				existing = "service-maker";
+			}
+
+			securityGroupParams = {
+				GroupNames : [ existing ]
 			};
-			return ec2.authorizeSecurityGroupIngressAsync(params);
-		})
-		.catch(function (error) {
-			if (error.name === "InvalidGroup.Duplicate") {
-				serverLog([ "info", "createSecurityGroup" ], "The Security Group already exists. No action needed.");
-			}
-			else if (error.message.match(/reserved/)) {
-				serverLog([ "error", "createSecurityGroup" ],
-				"The security group name is reserved. No group is created");
-			}
-			else {
-				serverLog([ "error", "createSecurityGroup" ], "Something went wrong with creating a security group.");
+
+			return ec2.describeSecurityGroupsAsync(securityGroupParams)
+			.then(function () {
+				return existing;
+			})
+			.catch(function (error) {
 				return Bluebird.reject(error);
-			}
-		});
+			});
+		}
+		else if (create !== undefined && existing === undefined) {
+
+			securityGroupParams = {
+				Description : "A security group created for use by Service Maker",
+				GroupName   : [ create ]
+			};
+
+			return ec2.createSecurityGroupAsync(securityGroupParams)
+			.then(function (data) {
+				var params = {
+					GroupName     : create,
+					GroupId       : data.GroupId,
+					IpPermissions : [ {
+						FromPort   : 22,
+						IpProtocol : "tcp",
+						ToPort     : 22,
+						IpRanges   : [ { CidrIp : "0.0.0.0/0" } ]
+					} ]
+				};
+				return ec2.authorizeSecurityGroupIngressAsync(params);
+			})
+			.then(function () {
+				return create;
+			})
+			.catch(function (error) {
+				return Bluebird.reject(error);
+			});
+		}
+		else {
+			var error = new Error();
+			error.name = "ValidationError";
+			error.message = "Bad request: Error with security groups.";
+			return Bluebird.reject(error);
+		}
 	};
 
 	this.stopInstances = function (instanceId) {

--- a/lib/services/awsAdapter.js
+++ b/lib/services/awsAdapter.js
@@ -256,7 +256,7 @@ function AWSAdapter (options) {
 		else {
 			var error = new Error();
 			error.name = "ValidationError";
-			error.message = "Bad request: Error with security groups.";
+			error.message = "Bad request: Both createSecurityGroup and existingSecurityGroup were specified.";
 			return Bluebird.reject(error);
 		}
 	};

--- a/lib/services/awsAdapter.js
+++ b/lib/services/awsAdapter.js
@@ -47,7 +47,7 @@ function AWSAdapter (options) {
 
 		var result = _.clone(instance);
 
-		return self.createSecurityGroup(instanceOptions.createSecurityGroup, instanceOptions.existingSecurityGroup)
+		return self.getSecurityGroup(instanceOptions.createSecurityGroup, instanceOptions.existingSecurityGroup)
 		.then(function (securityGroup) {
 			var params = {
 				ImageId        : instance.ami,
@@ -203,7 +203,7 @@ function AWSAdapter (options) {
 
 	};
 
-	this.createSecurityGroup = function (create, existing) {
+	this.getSecurityGroup = function (create, existing) {
 
 		var securityGroupParams;
 

--- a/test/unit/plugins/rest_spec.js
+++ b/test/unit/plugins/rest_spec.js
@@ -159,6 +159,50 @@ describe("The Rest plugin", function () {
 			});
 		});
 
+		describe("with valid parameters passed - using an existing security group", function () {
+			var result;
+
+			before(function () {
+				runInstancesStub = Sinon.stub(awsAdapter, "runInstances")
+				.returns(Bluebird.resolve({
+					id       : "0373ee03-ac16-42ec-b81c-37986d4bcb01",
+					ami      : "ami-d05e75b8",
+					type     : "t2.micro",
+					revision : 0,
+					state    : "pending",
+					uri      : null
+				}));
+
+				var request = new Request("POST", "/v1/instances").mime("application/json").payload({
+					ami                   : VALID_AMI,
+					type                  : VALID_TYPE,
+					existingSecurityGroup : VALID_SEC_GROUP
+				});
+				return request.inject(server)
+				.then(function (response) {
+					result = response;
+				});
+			});
+
+			after(function () {
+				runInstancesStub.restore();
+			});
+
+			it("creates the instance with the parameters passed", function () {
+				expect(runInstancesStub.firstCall.args[ 0 ].id).to.match(ID_REGEX);
+				expect(runInstancesStub.firstCall.args[ 0 ].ami).to.equal(VALID_AMI);
+				expect(runInstancesStub.firstCall.args[ 0 ].type).to.equal(VALID_TYPE);
+				expect(runInstancesStub.firstCall.args[ 0 ].state).to.equal("pending");
+				expect(runInstancesStub.firstCall.args[ 0 ].uri).to.equal(null);
+				expect(runInstancesStub.firstCall.args[ 1 ].existingSecurityGroup).to.equal(VALID_SEC_GROUP);
+			});
+
+			it("returns the canonical uri with appropriate an statusCode", function () {
+				expect(result.statusCode, "status").to.equal(201);
+				expect(result.headers.location, "location").to.match(location);
+			});
+		});
+
 		describe("with no parameters passed", function () {
 			var result;
 

--- a/test/unit/plugins/rest_spec.js
+++ b/test/unit/plugins/rest_spec.js
@@ -105,8 +105,8 @@ describe("The Rest plugin", function () {
 				expect(runInstancesStub.firstCall.args[ 0 ].ami).to.equal(VALID_AMI);
 				expect(runInstancesStub.firstCall.args[ 0 ].type).to.equal(VALID_TYPE);
 				expect(runInstancesStub.firstCall.args[ 0 ].state).to.equal("pending");
-				expect(runInstancesStub.firstCall.args[ 0 ].uri).to.equal(null);
-				expect(runInstancesStub.firstCall.args[ 1 ]).to.equal("service-maker");
+				expect(runInstancesStub.firstCall.args[ 1 ].createSecurityGroup).to.equal(undefined);
+				expect(runInstancesStub.firstCall.args[ 1 ].existingSecurityGroup).to.equal(undefined);
 			});
 
 			it("returns the canonical uri with appropriate an statusCode", function () {
@@ -115,7 +115,7 @@ describe("The Rest plugin", function () {
 			});
 		});
 
-		describe("with valid parameters passed - including a security group", function () {
+		describe("with valid parameters passed - creating a security group", function () {
 			var result;
 
 			before(function () {
@@ -130,9 +130,9 @@ describe("The Rest plugin", function () {
 				}));
 
 				var request = new Request("POST", "/v1/instances").mime("application/json").payload({
-					ami           : VALID_AMI,
-					type          : VALID_TYPE,
-					securityGroup : VALID_SEC_GROUP
+					ami                 : VALID_AMI,
+					type                : VALID_TYPE,
+					createSecurityGroup : VALID_SEC_GROUP
 				});
 				return request.inject(server)
 				.then(function (response) {
@@ -150,7 +150,7 @@ describe("The Rest plugin", function () {
 				expect(runInstancesStub.firstCall.args[ 0 ].type).to.equal(VALID_TYPE);
 				expect(runInstancesStub.firstCall.args[ 0 ].state).to.equal("pending");
 				expect(runInstancesStub.firstCall.args[ 0 ].uri).to.equal(null);
-				expect(runInstancesStub.firstCall.args[ 1 ]).to.equal(VALID_SEC_GROUP);
+				expect(runInstancesStub.firstCall.args[ 1 ].createSecurityGroup).to.equal(VALID_SEC_GROUP);
 			});
 
 			it("returns the canonical uri with appropriate an statusCode", function () {
@@ -190,7 +190,8 @@ describe("The Rest plugin", function () {
 				expect(runInstancesStub.firstCall.args[ 0 ].type).to.equal(VALID_TYPE);
 				expect(runInstancesStub.firstCall.args[ 0 ].state).to.equal("pending");
 				expect(runInstancesStub.firstCall.args[ 0 ].uri).to.equal(null);
-				expect(runInstancesStub.firstCall.args[ 1 ]).to.equal("service-maker");
+				expect(runInstancesStub.firstCall.args[ 1 ].createSecurityGroup).to.equal(undefined);
+				expect(runInstancesStub.firstCall.args[ 1 ].existingSecurityGroup).to.equal(undefined);
 			});
 
 			it("returns the canonical uri with appropriate an statusCode", function () {
@@ -309,7 +310,8 @@ describe("The Rest plugin", function () {
 				expect(runInstancesStub.firstCall.args[ 0 ].type).to.equal(VALID_TYPE);
 				expect(runInstancesStub.firstCall.args[ 0 ].state).to.equal("pending");
 				expect(runInstancesStub.firstCall.args[ 0 ].uri).to.equal(null);
-				expect(runInstancesStub.firstCall.args[ 1 ]).to.equal("service-maker");
+				expect(runInstancesStub.firstCall.args[ 1 ].createSecurityGroup).to.equal(undefined);
+				expect(runInstancesStub.firstCall.args[ 1 ].existingSecurityGroup).to.equal(undefined);
 			});
 
 			it("returns an error with statusCode 400", function () {
@@ -352,7 +354,8 @@ describe("The Rest plugin", function () {
 				expect(runInstancesStub.firstCall.args[ 0 ].type).to.equal("t2.notExist");
 				expect(runInstancesStub.firstCall.args[ 0 ].state).to.equal("pending");
 				expect(runInstancesStub.firstCall.args[ 0 ].uri).to.equal(null);
-				expect(runInstancesStub.firstCall.args[ 1 ]).to.equal("service-maker");
+				expect(runInstancesStub.firstCall.args[ 1 ].createSecurityGroup).to.equal(undefined);
+				expect(runInstancesStub.firstCall.args[ 1 ].existingSecurityGroup).to.equal(undefined);
 			});
 
 			it("returns an error with statusCode 400", function () {
@@ -375,9 +378,9 @@ describe("The Rest plugin", function () {
 				.rejects(SecurityGroupError);
 
 				var request = new Request("POST", "/v1/instances").mime("application/json").payload({
-					ami           : VALID_AMI,
-					type          : "t2.micro",
-					securityGroup : "reserved-group"
+					ami                 : VALID_AMI,
+					type                : "t2.micro",
+					createSecurityGroup : "reserved-group"
 				});
 
 				return request.inject(server)
@@ -397,7 +400,8 @@ describe("The Rest plugin", function () {
 				expect(runInstancesStub.firstCall.args[ 0 ].type).to.equal(VALID_TYPE);
 				expect(runInstancesStub.firstCall.args[ 0 ].state).to.equal("pending");
 				expect(runInstancesStub.firstCall.args[ 0 ].uri).to.equal(null);
-				expect(runInstancesStub.firstCall.args[ 1 ]).to.equal("reserved-group");
+				expect(runInstancesStub.firstCall.args[ 1 ].createSecurityGroup).to.equal("reserved-group");
+				expect(runInstancesStub.firstCall.args[ 1 ].existingSecurityGroup).to.equal(undefined);
 			});
 
 			it("returns an error with statusCode 400", function () {

--- a/test/unit/services/awsAdapter_spec.js
+++ b/test/unit/services/awsAdapter_spec.js
@@ -379,7 +379,7 @@ describe("The AwsAdapter class ", function () {
 				AMIError.name = "InvalidAMIID.Malformed";
 				AMIError.message = "The AMI entered does not exist. Ensure it is of the form ami-xxxxxx.";
 
-				createSecurityGroupStub = Sinon.stub(awsAdapter, "createSecurityGroup").resolves("test");
+				createSecurityGroupStub = Sinon.stub(awsAdapter, "getSecurityGroup").resolves("test");
 
 				runInstancesStub = Sinon.stub(ec2, "runInstancesAsync").rejects(AMIError);
 
@@ -419,7 +419,7 @@ describe("The AwsAdapter class ", function () {
 				TypeError.name = "InvalidParameterValue";
 				TypeError.message = "The Type entered does not exist. Ensure it is a valid EC2 type.";
 
-				createSecurityGroupStub = Sinon.stub(awsAdapter, "createSecurityGroup").resolves("test");
+				createSecurityGroupStub = Sinon.stub(awsAdapter, "getSecurityGroup").resolves("test");
 
 				runInstancesStub = Sinon.stub(ec2, "runInstancesAsync").rejects(TypeError);
 

--- a/test/unit/services/awsAdapter_spec.js
+++ b/test/unit/services/awsAdapter_spec.js
@@ -25,7 +25,31 @@ describe("The AwsAdapter class ", function () {
 	var VALID_AWS_ID       = "i-1234567";
 	var VALID_ID           = "da14fbf2-5404-4f92-b55f-a961578204ed";
 	var DEFAULT_GROUP_ID   = "sg-a1234567";
-	var DEFAULT_SG_NAME    = "service-maker";
+
+	var CREATE_SECURITY_OPTIONS = {
+		createSecurityGroup   : "created-group",
+		existingSecurityGroup : undefined
+	};
+
+	var EXISTING_SECURITY_OPTIONS = {
+		createSecurityGroup   : undefined,
+		existingSecurityGroup : "existing-group"
+	};
+
+	var INVALID_SECURITY_OPTIONS = {
+		createSecurityGroup   : "created-group",
+		existingSecurityGroup : "existing-group"
+	};
+
+	var RESERVED_SECURITY_OPTIONS = {
+		createSecurityGroup   : "reserved-group",
+		existingSecurityGroup : undefined
+	};
+
+	var DEFAULT_SECURITY_OPTIONS = {
+		createSecurityGroup   : undefined,
+		existingSecurityGroup : undefined
+	};
 
 	var DEFAULT_SSH_RULE = {
 		FromPort   : 22,
@@ -59,7 +83,6 @@ describe("The AwsAdapter class ", function () {
 
 	describe("trying to create a new instance", function () {
 		var createTagsStub;
-		var result;
 		var awsAdapter = new AwsAdapter(awsOptions);
 
 		before(function () {
@@ -72,10 +95,12 @@ describe("The AwsAdapter class ", function () {
 			createTagsStub.restore();
 		});
 
-		describe("with valid parameters", function () {
+		describe("with valid parameters, creating a security group", function () {
 
+			var result;
 			var runInstancesStub;
 			var beginPollingStub;
+			var describeSecurityGroupsStub;
 			var createSecurityGroupStub;
 			var authorizeSecurityGroupIngressStub;
 
@@ -93,9 +118,12 @@ describe("The AwsAdapter class ", function () {
 						} ]
 				});
 
+				describeSecurityGroupsStub = Sinon.stub(ec2, "describeSecurityGroupsAsync")
+				.resolves("test");
+
 				beginPollingStub = Sinon.stub(awsAdapter,"beginPolling");
 
-				awsAdapter.runInstances(VALID_INSTANCE, DEFAULT_SG_NAME)
+				return awsAdapter.runInstances(VALID_INSTANCE, CREATE_SECURITY_OPTIONS)
 				.then(function (response) {
 					result = response;
 				});
@@ -105,50 +133,43 @@ describe("The AwsAdapter class ", function () {
 				runInstancesStub.restore();
 				beginPollingStub.restore();
 				createSecurityGroupStub.restore();
+				describeSecurityGroupsStub.restore();
 				authorizeSecurityGroupIngressStub.restore();
 			});
 
 			it("creates the security group", function () {
-				expect(createSecurityGroupStub.args[ 0 ][ 0 ].GroupName).to.equal(DEFAULT_SG_NAME);
+				expect(createSecurityGroupStub.firstCall.args[ 0 ].GroupName[ 0 ]).to.equal("created-group");
 			});
 
 			it("adds rules for SSH to the security group", function () {
-				expect(authorizeSecurityGroupIngressStub.args[ 0 ][ 0 ].GroupId).to.equal(DEFAULT_GROUP_ID);
-				expect(authorizeSecurityGroupIngressStub.args[ 0 ][ 0 ].GroupName).to.equal(DEFAULT_SG_NAME);
-				expect(authorizeSecurityGroupIngressStub.args[ 0 ][ 0 ].IpPermissions[ 0 ])
+				expect(authorizeSecurityGroupIngressStub.firstCall.args[ 0 ].GroupId).to.equal(DEFAULT_GROUP_ID);
+				expect(authorizeSecurityGroupIngressStub.firstCall.args[ 0 ].GroupName).to.equal("created-group");
+				expect(authorizeSecurityGroupIngressStub.firstCall.args[ 0 ].IpPermissions[ 0 ])
 				.to.deep.equal(DEFAULT_SSH_RULE);
 			});
 
-			it("and returns a new instance with the ami and type provided", function () {
+			it("creates the instance with the ami, type and new security group", function () {
 				expect(runInstancesStub.args[ 0 ][ 0 ].ImageId).to.equal(DEFAULT_AMI);
 				expect(runInstancesStub.args[ 0 ][ 0 ].InstanceType).to.equal(DEFAULT_TYPE);
 				expect(runInstancesStub.args[ 0 ][ 0 ].MaxCount).to.equal(1);
 				expect(runInstancesStub.args[ 0 ][ 0 ].MinCount).to.equal(1);
-				expect(runInstancesStub.args[ 0 ][ 0 ].SecurityGroups[ 0 ]).to.equal(DEFAULT_SG_NAME);
+				expect(runInstancesStub.args[ 0 ][ 0 ].SecurityGroups[ 0 ]).to.equal("created-group");
+			});
 
+			it("returns the instance to the user", function  () {
 				expect(result.ami, "response").to.equal("ami-d05e75b8");
 				expect(result.type, "response").to.equal("t2.micro");
 			});
 		});
 
-		describe("with a security group name that already exists", function () {
+		describe("with a security group that already exists", function () {
 
+			var result;
 			var runInstancesStub;
 			var beginPollingStub;
-			var createSecurityGroupStub;
-			var authorizeSecurityGroupIngressStub;
+			var describeSecurityGroupsStub;
 
 			before(function () {
-
-				var error     = new Error();
-				error.message = "The security group already exists";
-				error.name    = "InvalidGroup.Duplicate";
-
-				createSecurityGroupStub = Sinon.stub(ec2, "createSecurityGroupAsync")
-				.rejects(error);
-
-				authorizeSecurityGroupIngressStub = Sinon.stub(ec2, "authorizeSecurityGroupIngressAsync")
-				.resolves("test");
 
 				runInstancesStub = Sinon.stub(ec2, "runInstancesAsync").resolves({
 						Instances : [ {
@@ -156,9 +177,12 @@ describe("The AwsAdapter class ", function () {
 						} ]
 				});
 
-				beginPollingStub = Sinon.stub(awsAdapter,"beginPolling");
+				describeSecurityGroupsStub = Sinon.stub(ec2, "describeSecurityGroupsAsync")
+				.resolves("test");
 
-				awsAdapter.runInstances(VALID_INSTANCE, DEFAULT_SG_NAME)
+				beginPollingStub = Sinon.stub(awsAdapter, "beginPolling");
+
+				return awsAdapter.runInstances(VALID_INSTANCE, EXISTING_SECURITY_OPTIONS)
 				.then(function (response) {
 					result = response;
 				});
@@ -167,48 +191,31 @@ describe("The AwsAdapter class ", function () {
 			after(function () {
 				runInstancesStub.restore();
 				beginPollingStub.restore();
-				createSecurityGroupStub.restore();
-				authorizeSecurityGroupIngressStub.restore();
+				describeSecurityGroupsStub.restore();
 			});
 
-			it("finds the group already created", function () {
-				expect(createSecurityGroupStub.args[ 0 ][ 0 ].GroupName).to.equal(DEFAULT_SG_NAME);
-			});
-
-			it("checks that it isn't modified", function () {
-				expect(authorizeSecurityGroupIngressStub.callCount).to.equal(0);
-			});
-
-			it("and returns a new instance with the ami and type provided", function () {
+			it("and returns a new instance with the ami, type and existing security group", function () {
 				expect(runInstancesStub.args[ 0 ][ 0 ].ImageId).to.equal(DEFAULT_AMI);
 				expect(runInstancesStub.args[ 0 ][ 0 ].InstanceType).to.equal(DEFAULT_TYPE);
 				expect(runInstancesStub.args[ 0 ][ 0 ].MaxCount).to.equal(1);
 				expect(runInstancesStub.args[ 0 ][ 0 ].MinCount).to.equal(1);
-				expect(runInstancesStub.args[ 0 ][ 0 ].SecurityGroups[ 0 ]).to.equal(DEFAULT_SG_NAME);
+				expect(runInstancesStub.args[ 0 ][ 0 ].SecurityGroups[ 0 ]).to.equal("existing-group");
+			});
 
+			it("returns the instance to the user", function () {
 				expect(result.ami, "response").to.equal("ami-d05e75b8");
 				expect(result.type, "response").to.equal("t2.micro");
 			});
 		});
 
-		describe("with a security group name that is reserved", function () {
+		describe("with the default security group", function () {
 
+			var result;
 			var runInstancesStub;
 			var beginPollingStub;
-			var createSecurityGroupStub;
-			var authorizeSecurityGroupIngressStub;
+			var describeSecurityGroupsStub;
 
 			before(function () {
-
-				var error     = new Error();
-				error.message = "The security group name used is reserved.";
-				error.name    = "InvalidParameters";
-
-				createSecurityGroupStub = Sinon.stub(ec2, "createSecurityGroupAsync")
-				.rejects(error);
-
-				authorizeSecurityGroupIngressStub = Sinon.stub(ec2, "authorizeSecurityGroupIngressAsync")
-				.resolves("test");
 
 				runInstancesStub = Sinon.stub(ec2, "runInstancesAsync").resolves({
 						Instances : [ {
@@ -216,9 +223,12 @@ describe("The AwsAdapter class ", function () {
 						} ]
 				});
 
-				beginPollingStub = Sinon.stub(awsAdapter,"beginPolling");
+				describeSecurityGroupsStub = Sinon.stub(ec2, "describeSecurityGroupsAsync")
+				.resolves("test");
 
-				awsAdapter.runInstances(VALID_INSTANCE, DEFAULT_SG_NAME)
+				beginPollingStub = Sinon.stub(awsAdapter, "beginPolling");
+
+				return awsAdapter.runInstances(VALID_INSTANCE, DEFAULT_SECURITY_OPTIONS)
 				.then(function (response) {
 					result = response;
 				});
@@ -227,47 +237,100 @@ describe("The AwsAdapter class ", function () {
 			after(function () {
 				runInstancesStub.restore();
 				beginPollingStub.restore();
-				createSecurityGroupStub.restore();
-				authorizeSecurityGroupIngressStub.restore();
+				describeSecurityGroupsStub.restore();
 			});
 
-			it("finds the group already created", function () {
-				expect(createSecurityGroupStub.args[ 0 ][ 0 ].GroupName).to.equal(DEFAULT_SG_NAME);
-			});
-
-			it("checks that it isn't modified", function () {
-				expect(authorizeSecurityGroupIngressStub.callCount).to.equal(0);
-			});
-
-			it("and returns a new instance with the ami and type provided", function () {
+			it("and returns a new instance with the ami, type and default security group", function () {
 				expect(runInstancesStub.args[ 0 ][ 0 ].ImageId).to.equal(DEFAULT_AMI);
 				expect(runInstancesStub.args[ 0 ][ 0 ].InstanceType).to.equal(DEFAULT_TYPE);
 				expect(runInstancesStub.args[ 0 ][ 0 ].MaxCount).to.equal(1);
 				expect(runInstancesStub.args[ 0 ][ 0 ].MinCount).to.equal(1);
-				expect(runInstancesStub.args[ 0 ][ 0 ].SecurityGroups[ 0 ]).to.equal(DEFAULT_SG_NAME);
+				expect(runInstancesStub.args[ 0 ][ 0 ].SecurityGroups[ 0 ]).to.equal("service-maker");
+			});
 
+			it("returns the instance to the user", function () {
 				expect(result.ami, "response").to.equal("ami-d05e75b8");
 				expect(result.type, "response").to.equal("t2.micro");
 			});
 		});
 
-		describe("when an error occurs with creating the security group", function () {
+		describe("when a reserved security group name is used", function () {
 
-			var runInstancesStub;
-			var beginPollingStub;
+			var result;
+			var describeSecurityGroupsStub;
 			var createSecurityGroupStub;
 			var authorizeSecurityGroupIngressStub;
+
+			before(function () {
+
+				var error = new Error();
+				error.name = "InvalidGroup.Reserved";
+				createSecurityGroupStub = Sinon.stub(ec2, "createSecurityGroupAsync")
+				.rejects(error);
+
+				authorizeSecurityGroupIngressStub = Sinon.stub(ec2, "authorizeSecurityGroupIngressAsync")
+				.resolves("test");
+
+				describeSecurityGroupsStub = Sinon.stub(ec2, "describeSecurityGroupsAsync")
+				.resolves("test");
+
+				return awsAdapter.runInstances(VALID_INSTANCE, RESERVED_SECURITY_OPTIONS)
+				.catch(function (error) {
+					result = error;
+				});
+			});
+
+			after(function () {
+				createSecurityGroupStub.restore();
+				describeSecurityGroupsStub.restore();
+				authorizeSecurityGroupIngressStub.restore();
+			});
+
+			it("calls createSecurityGroupAsync with the correct parameters", function () {
+				expect(createSecurityGroupStub.firstCall.args[ 0 ].GroupName[ 0 ]).to.equal("reserved-group");
+			});
+
+			it("no security group rules are created", function () {
+				expect(authorizeSecurityGroupIngressStub.callCount).to.equal(0);
+			});
+
+			it("throws an error", function  () {
+				expect(result).to.be.instanceOf(Error);
+				expect(result.name).to.equal("InvalidGroup.Reserved");
+			});
+		});
+
+		describe("when both create and existing security group parameters are set", function () {
+
 			var result;
 
 			before(function () {
 
-				var error     = new Error("Simulated Error");
+				return awsAdapter.runInstances(VALID_INSTANCE, INVALID_SECURITY_OPTIONS)
+				.catch(function (error) {
+					result = error;
+				});
+			});
 
-				createSecurityGroupStub = Sinon.stub(ec2, "createSecurityGroupAsync")
+			it("throws an error", function () {
+				expect(result.name).to.equal("ValidationError");
+				expect(result.message).to.equal("Bad request: Error with security groups.");
+			});
+		});
+
+		describe("when an error occurs with using an existing security group", function () {
+
+			var result;
+
+			var runInstancesStub;
+			var describeSecurityGroupsStub;
+
+			before(function () {
+
+				var error = new Error("Simulated Error");
+
+				describeSecurityGroupsStub = Sinon.stub(ec2, "describeSecurityGroupsAsync")
 				.rejects(error);
-
-				authorizeSecurityGroupIngressStub = Sinon.stub(ec2, "authorizeSecurityGroupIngressAsync")
-				.resolves("test");
 
 				runInstancesStub = Sinon.stub(ec2, "runInstancesAsync").resolves({
 						Instances : [ {
@@ -275,9 +338,7 @@ describe("The AwsAdapter class ", function () {
 						} ]
 				});
 
-				beginPollingStub = Sinon.stub(awsAdapter,"beginPolling");
-
-				awsAdapter.runInstances(VALID_INSTANCE, DEFAULT_SG_NAME)
+				return awsAdapter.runInstances(VALID_INSTANCE, DEFAULT_SECURITY_OPTIONS)
 				.then(function (response) {
 					result = response;
 				})
@@ -288,13 +349,14 @@ describe("The AwsAdapter class ", function () {
 
 			after(function () {
 				runInstancesStub.restore();
-				beginPollingStub.restore();
-				createSecurityGroupStub.restore();
-				authorizeSecurityGroupIngressStub.restore();
+				describeSecurityGroupsStub.restore();
 			});
 
-			it("expects an error", function () {
-				expect(createSecurityGroupStub.args[ 0 ][ 0 ].GroupName).to.equal(DEFAULT_SG_NAME);
+			it("calls describeSecurityGroupsAsync with the correct parameters", function () {
+				expect(describeSecurityGroupsStub.firstCall.args[ 0 ].GroupNames[ 0 ]).to.equal("service-maker");
+			});
+
+			it("throws an error", function () {
 				expect(result, "error").to.be.instanceof(Error);
 				expect(result.message).to.equal("Simulated Error");
 			});
@@ -303,13 +365,11 @@ describe("The AwsAdapter class ", function () {
 				expect(runInstancesStub.callCount).to.equal(0);
 			});
 
-			it("doesn't try adding rules to the security group", function () {
-				expect(authorizeSecurityGroupIngressStub.callCount).to.equal(0);
-			});
 		});
 
 		describe("with invalid ami", function () {
 
+			var result;
 			var runInstancesStub;
 			var createSecurityGroupStub;
 
@@ -323,7 +383,7 @@ describe("The AwsAdapter class ", function () {
 
 				runInstancesStub = Sinon.stub(ec2, "runInstancesAsync").rejects(AMIError);
 
-				awsAdapter.runInstances(INVALID_INSTANCE_AMI)
+				return awsAdapter.runInstances(INVALID_INSTANCE_AMI, DEFAULT_SECURITY_OPTIONS)
 				.then(function (response) {
 					result = response;
 				})
@@ -349,6 +409,7 @@ describe("The AwsAdapter class ", function () {
 
 		describe("with invalid type", function () {
 
+			var result;
 			var runInstancesStub;
 			var createSecurityGroupStub;
 
@@ -362,7 +423,7 @@ describe("The AwsAdapter class ", function () {
 
 				runInstancesStub = Sinon.stub(ec2, "runInstancesAsync").rejects(TypeError);
 
-				awsAdapter.runInstances(INVALID_INSTANCE_TYPE)
+				return awsAdapter.runInstances(INVALID_INSTANCE_TYPE, DEFAULT_SECURITY_OPTIONS)
 				.then(function (response) {
 					result = response;
 				})

--- a/test/unit/services/awsAdapter_spec.js
+++ b/test/unit/services/awsAdapter_spec.js
@@ -314,7 +314,8 @@ describe("The AwsAdapter class ", function () {
 
 			it("throws an error", function () {
 				expect(result.name).to.equal("ValidationError");
-				expect(result.message).to.equal("Bad request: Error with security groups.");
+				expect(result.message).to
+				.equal("Bad request: Both createSecurityGroup and existingSecurityGroup were specified.");
 			});
 		});
 


### PR DESCRIPTION
- now use separate parameters for creating or using an existing group
- rework test cases to indicate this
