### PR TITLE
Using key-pairs is now possible.

### DIFF
--- a/lib/plugins/rest.js
+++ b/lib/plugins/rest.js
@@ -16,17 +16,21 @@ exports.register = function (server, options, next) {
 		region : "us-east-1"
 	});
 
+	var s3 = new AWS.S3();
+
 	Bluebird.promisifyAll(ec2);
+	Bluebird.promisifyAll(s3);
+
 	Bluebird.promisifyAll(Catbox);
 
 	var instances     = options.instances || new InstanceAdapter(options.mapper);
-	var awsOptions    = { serverLog : server.log.bind(server), instances : instances, ec2 : ec2 };
+	var awsOptions    = { serverLog : server.log.bind(server), instances : instances, ec2 : ec2, s3 : s3 };
 	var catboxOptions = {
 		partition : "cachedId"
 	};
 	var cacheClient   = options.cache || new Catbox.Client(CatboxMemory, catboxOptions);
-	var awsAdapter;
 
+	var awsAdapter;
 	try {
 		awsAdapter = options.awsAdapter || new AwsAdapter(awsOptions);
 	}
@@ -56,9 +60,9 @@ exports.register = function (server, options, next) {
 
 			var instanceOptions = {
 				createSecurityGroup   : request.payload.createSecurityGroup,
-				existingSecurityGroup : request.payload.existingSecurityGroup
-				createkeyName         : request.payload.createkeyName,
-				existingKeyName       : request.payload.createkeyName,
+				existingSecurityGroup : request.payload.existingSecurityGroup,
+				createKeyName         : request.payload.createKeyName,
+				existingKeyName       : request.payload.existingKeyName
 			};
 
 			instances.createInstance(ami, type)
@@ -67,7 +71,8 @@ exports.register = function (server, options, next) {
 				return awsAdapter.runInstances(instance, instanceOptions);
 			})
 			.then(function (instance) {
-				reply(instance).created("/v1/instances/" + instance.id);
+				reply(instance).created("/v1/instances/" + instance.id)
+				.header("private-key-location", "instance.keyLocation");
 			})
 			.catch(function (error) {
 				var failedInstance;

--- a/lib/plugins/rest.js
+++ b/lib/plugins/rest.js
@@ -73,7 +73,7 @@ exports.register = function (server, options, next) {
 			.then(function (instance) {
 				if (instance.keyLocation) {
 					reply(instance).created("/v1/instances/" + instance.id)
-					.header("privatekeylocation", instance.keyLocation);
+					.header("PrivateKeyLocation", instance.keyLocation);
 				}
 				else {
 					reply(instance).created("/v1/instances/" + instance.id);

--- a/lib/plugins/rest.js
+++ b/lib/plugins/rest.js
@@ -81,6 +81,7 @@ exports.register = function (server, options, next) {
 			})
 			.catch(function (error) {
 				var failedInstance;
+				console.log(error);
 				switch (error.name) {
 
 					case ("ValidationError") : {

--- a/lib/plugins/rest.js
+++ b/lib/plugins/rest.js
@@ -57,6 +57,8 @@ exports.register = function (server, options, next) {
 			var instanceOptions = {
 				createSecurityGroup   : request.payload.createSecurityGroup,
 				existingSecurityGroup : request.payload.existingSecurityGroup
+				createkeyName         : request.payload.createkeyName,
+				existingKeyName       : request.payload.createkeyName,
 			};
 
 			instances.createInstance(ami, type)

--- a/lib/plugins/rest.js
+++ b/lib/plugins/rest.js
@@ -71,8 +71,13 @@ exports.register = function (server, options, next) {
 				return awsAdapter.runInstances(instance, instanceOptions);
 			})
 			.then(function (instance) {
-				reply(instance).created("/v1/instances/" + instance.id)
-				.header("private-key-location", "instance.keyLocation");
+				if (instance.keyLocation) {
+					reply(instance).created("/v1/instances/" + instance.id)
+					.header("privatekeylocation", instance.keyLocation);
+				}
+				else {
+					reply(instance).created("/v1/instances/" + instance.id);
+				}
 			})
 			.catch(function (error) {
 				var failedInstance;

--- a/lib/plugins/rest.js
+++ b/lib/plugins/rest.js
@@ -81,7 +81,6 @@ exports.register = function (server, options, next) {
 			})
 			.catch(function (error) {
 				var failedInstance;
-				console.log(error);
 				switch (error.name) {
 
 					case ("ValidationError") : {

--- a/lib/services/awsAdapter.js
+++ b/lib/services/awsAdapter.js
@@ -49,12 +49,14 @@ function AWSAdapter (options) {
 
 		return self.getSecurityGroup(instanceOptions.createSecurityGroup, instanceOptions.existingSecurityGroup)
 		.then(function (securityGroup) {
+
 			var params = {
 				ImageId        : instance.ami,
 				InstanceType   : instance.type,
 				MinCount       : 1,
 				MaxCount       : 1,
-				SecurityGroups : [ securityGroup ]
+				SecurityGroups : [ instanceOptions.securityGroup ],
+				KeyName        : [ keyPairName ]
 			};
 
 			return ec2.runInstancesAsync(params);
@@ -256,6 +258,53 @@ function AWSAdapter (options) {
 			error.name = "ValidationError";
 			error.message = "Bad request: Both createSecurityGroup and existingSecurityGroup were specified.";
 			return Bluebird.reject(error);
+		}
+	};
+
+	this.createKeyPair = function (createKeyName, existingKeyName) {
+
+		var keyPairParams;
+		var createKey;
+
+		if (createKeyName !== undefined && existingKeyName === undefined) {
+			keyPairParams = {
+				KeyName : createKeyName
+			};
+			createKey = true;
+		}
+		else if (createKeyName === undefined && existingKeyName !== undefined) {
+			keyPairParams = {
+				KeyName : [ createKeyName ]
+			};
+			createKey = false;
+		}
+		else if (createKeyName === undefined && existingKeyName === undefined) {
+			//Default name of the key-pair.
+			keyPairParams = {
+				KeyName : [ "service-maker" ]
+			};
+			createKey = false;
+		}
+		else {
+			var error     = new Error();
+			error.name    = "ValidationError";
+			error.message = "Two key-pair names were specified.";
+			throw error;
+		}
+
+		if (createKey) {
+
+			return ec2.createKeyPairAsync(keyPairParams)
+			.catch(function (error) {
+				return Bluebird.reject(error);
+			});
+		}
+		else {
+
+			return ec2.describeKeyPairsAsync(keyPairParams)
+			.catch(function (error) {
+				return Bluebird.reject(error);
+			});
 		}
 	};
 

--- a/lib/services/awsAdapter.js
+++ b/lib/services/awsAdapter.js
@@ -16,6 +16,7 @@ function AWSAdapter (options) {
 	var serverLog;
 	var ec2;
 	var s3;
+	var DEFAULT_BUCKET = "https://s3.amazonaws.com/service-maker/";
 	var schema = Joi.object().keys({
 		sshAdapter : Joi.object().type(SshAdapter).required(),
 		ec2        : Joi.object().type(AWS.EC2).required(),
@@ -280,8 +281,9 @@ function AWSAdapter (options) {
 
 		if (createKeyName === undefined) {
 			if (existingKeyName === undefined) {
-				//Default name of the Service Maker key-pair.
+				//Default name and location of the Service Maker key-pair.
 				existingKeyName = "service-maker";
+				keyPair.keyLocation = DEFAULT_BUCKET + existingKeyName + ".pem";
 			}
 
 			keyPair.name = existingKeyName;

--- a/lib/services/awsAdapter.js
+++ b/lib/services/awsAdapter.js
@@ -272,6 +272,7 @@ function AWSAdapter (options) {
 
 	this.getKeyPair = function (createKeyName, existingKeyName) {
 
+		var self = this;
 		var keyPairParams;
 
 		var keyPair = {
@@ -300,21 +301,12 @@ function AWSAdapter (options) {
 				if (error.name === "InvalidKeyPair.NotFound") {
 
 					keyPairParams = {
-						KeyNames : existingKeyName
+						KeyName : existingKeyName
 					};
 
-					return ec2.createKeyPairAsync(keyPairParams)
-					.then(function (key) {
-						var params = {
-							Bucket : "service-maker",
-							Key    : existingKeyName + ".pem",
-							Body   : key.KeyMaterial
-						};
-						return s3.uploadAsync(params);
-					})
+					return self.createKey(keyPairParams)
 					.then(function (result) {
-						keyPair.name = existingKeyName;
-						keyPair.keyLocation = result.Location;
+						keyPair = result;
 						return keyPair;
 					})
 					.catch(function (error) {
@@ -331,18 +323,9 @@ function AWSAdapter (options) {
 				KeyName : createKeyName
 			};
 
-			return ec2.createKeyPairAsync(keyPairParams)
-			.then(function (key) {
-				var params = {
-					Bucket : "service-maker",
-					Key    : createKeyName + ".pem",
-					Body   : key.KeyMaterial
-				};
-				return s3.uploadAsync(params);
-			})
+			return self.createKey(keyPairParams)
 			.then(function (result) {
-				keyPair.name = createKeyName;
-				keyPair.keyLocation = result.Location;
+				keyPair = result;
 				return keyPair;
 			})
 			.catch(function (error) {
@@ -355,6 +338,30 @@ function AWSAdapter (options) {
 			error.message = "Bad request: Both createKeyName and existingKeyName were specified.";
 			return Bluebird.reject(error);
 		}
+	};
+
+	this.createKey = function (keyPairParams) {
+		var keyPair = {
+			keyLocation : undefined,
+			name        : undefined
+		};
+		return ec2.createKeyPairAsync(keyPairParams)
+		.then(function (key) {
+			var params = {
+				Bucket : "service-maker",
+				Key    : keyPairParams.KeyName + ".pem",
+				Body   : key.KeyMaterial
+			};
+			return s3.uploadAsync(params);
+		})
+		.then(function (result) {
+			keyPair.name = keyPairParams.KeyName;
+			keyPair.keyLocation = result.Location;
+			return keyPair;
+		})
+		.catch(function (error) {
+			return Bluebird.reject(error);
+		});
 	};
 
 	this.stopInstances = function (instanceId) {

--- a/lib/services/awsAdapter.js
+++ b/lib/services/awsAdapter.js
@@ -297,7 +297,7 @@ function AWSAdapter (options) {
 			var error     = new Error();
 			error.name    = "ValidationError";
 			error.message = "Two key-pair names were specified.";
-			throw error;
+			return Bluebird.reject(error);
 		}
 
 	};

--- a/lib/services/awsAdapter.js
+++ b/lib/services/awsAdapter.js
@@ -305,7 +305,7 @@ function AWSAdapter (options) {
 					.then(function (key) {
 						var params = {
 							Bucket : "service-maker",
-							Key    : createKeyName + ".pem",
+							Key    : existingKeyName + ".pem",
 							Body   : key.KeyMaterial
 						};
 						return s3.uploadAsync(params);

--- a/lib/services/awsAdapter.js
+++ b/lib/services/awsAdapter.js
@@ -55,7 +55,7 @@ function AWSAdapter (options) {
 		return self.createSecurityGroup(instanceOptions.createSecurityGroup, instanceOptions.existingSecurityGroup)
 		.then(function (securityGroupName) {
 			securityGroup = securityGroupName;
-			return self.createKeyPair(instanceOptions.createKeyName, instanceOptions.existingKeyName);
+			return self.getKeyPair(instanceOptions.createKeyName, instanceOptions.existingKeyName);
 		})
 		.then(function (keyPair) {
 			var params = {
@@ -269,7 +269,7 @@ function AWSAdapter (options) {
 		}
 	};
 
-	this.createKeyPair = function (createKeyName, existingKeyName) {
+	this.getKeyPair = function (createKeyName, existingKeyName) {
 
 		var keyPairParams;
 

--- a/lib/services/awsAdapter.js
+++ b/lib/services/awsAdapter.js
@@ -312,7 +312,6 @@ function AWSAdapter (options) {
 					})
 					.then(function (result) {
 						keyPair.name = existingKeyName;
-						console.log(result);
 						keyPair.keyLocation = result.Location;
 						return keyPair;
 					})

--- a/lib/services/awsAdapter.js
+++ b/lib/services/awsAdapter.js
@@ -7,9 +7,6 @@ var InstanceAdapter = require("./instanceAdapter");
 var Joi             = require("joi");
 var AWS             = require("aws-sdk");
 var _               = require("lodash");
-var fs              = require("fs");
-
-Bluebird.promisifyAll(fs);
 
 function AWSAdapter (options) {
 	var tags;

--- a/lib/services/awsAdapter.js
+++ b/lib/services/awsAdapter.js
@@ -53,7 +53,7 @@ function AWSAdapter (options) {
 
 		var securityGroup;
 
-		return self.createSecurityGroup(instanceOptions.createSecurityGroup, instanceOptions.existingSecurityGroup)
+		return self.getSecurityGroup(instanceOptions.createSecurityGroup, instanceOptions.existingSecurityGroup)
 		.then(function (securityGroupName) {
 			securityGroup = securityGroupName;
 			return self.getKeyPair(instanceOptions.createKeyName, instanceOptions.existingKeyName);
@@ -212,7 +212,7 @@ function AWSAdapter (options) {
 
 	};
 
-	this.createSecurityGroup = function (create, existing) {
+	this.getSecurityGroup = function (create, existing) {
 
 		var securityGroupParams;
 

--- a/lib/services/awsAdapter.js
+++ b/lib/services/awsAdapter.js
@@ -264,26 +264,34 @@ function AWSAdapter (options) {
 	this.createKeyPair = function (createKeyName, existingKeyName) {
 
 		var keyPairParams;
-		var createKey;
 
-		if (createKeyName !== undefined && existingKeyName === undefined) {
+		if (createKeyName === undefined) {
+			if (existingKeyName === undefined) {
+				//Default key pair name
+				existingKeyName = "service-maker";
+			}
+
+			keyPairParams = {
+				KeyNames : [ existingKeyName ]
+			};
+
+			return ec2.describeKeyPairsAsync(keyPairParams)
+			.catch(function (error) {
+				return Bluebird.reject(error);
+			});
+		}
+
+		else if (createKeyName !== undefined && existingKeyName === undefined) {
+
 			keyPairParams = {
 				KeyName : createKeyName
 			};
-			createKey = true;
-		}
-		else if (createKeyName === undefined && existingKeyName !== undefined) {
-			keyPairParams = {
-				KeyName : [ createKeyName ]
-			};
-			createKey = false;
-		}
-		else if (createKeyName === undefined && existingKeyName === undefined) {
-			//Default name of the key-pair.
-			keyPairParams = {
-				KeyName : [ "service-maker" ]
-			};
-			createKey = false;
+
+			return ec2.createKeyPairAsync(keyPairParams)
+			.catch(function (error) {
+				return Bluebird.reject(error);
+			});
+
 		}
 		else {
 			var error     = new Error();
@@ -292,20 +300,6 @@ function AWSAdapter (options) {
 			throw error;
 		}
 
-		if (createKey) {
-
-			return ec2.createKeyPairAsync(keyPairParams)
-			.catch(function (error) {
-				return Bluebird.reject(error);
-			});
-		}
-		else {
-
-			return ec2.describeKeyPairsAsync(keyPairParams)
-			.catch(function (error) {
-				return Bluebird.reject(error);
-			});
-		}
 	};
 
 	this.stopInstances = function (instanceId) {

--- a/lib/services/awsAdapter.js
+++ b/lib/services/awsAdapter.js
@@ -7,6 +7,9 @@ var InstanceAdapter = require("./instanceAdapter");
 var Joi             = require("joi");
 var AWS             = require("aws-sdk");
 var _               = require("lodash");
+var fs              = require("fs");
+
+Bluebird.promisifyAll(fs);
 
 function AWSAdapter (options) {
 	var tags;
@@ -15,9 +18,11 @@ function AWSAdapter (options) {
 	var instances;
 	var serverLog;
 	var ec2;
+	var s3;
 	var schema = Joi.object().keys({
 		sshAdapter : Joi.object().type(SshAdapter).required(),
 		ec2        : Joi.object().type(AWS.EC2).required(),
+		s3         : Joi.object().type(AWS.S3).required(),
 		serverLog  : Joi.func().required(),
 		instances  : Joi.object().type(InstanceAdapter).required()
 	});
@@ -33,6 +38,7 @@ function AWSAdapter (options) {
 		instances  = options.instances;
 		serverLog  = options.serverLog;
 		ec2        = options.ec2;
+		s3         = options.s3;
 	}
 
 	var JoiValidator = Joi.validate(options, schema);
@@ -47,18 +53,23 @@ function AWSAdapter (options) {
 
 		var result = _.clone(instance);
 
-		return self.getSecurityGroup(instanceOptions.createSecurityGroup, instanceOptions.existingSecurityGroup)
-		.then(function (securityGroup) {
+		var securityGroup;
 
+		return self.createSecurityGroup(instanceOptions.createSecurityGroup, instanceOptions.existingSecurityGroup)
+		.then(function (securityGroupName) {
+			securityGroup = securityGroupName;
+			return self.createKeyPair(instanceOptions.createKeyName, instanceOptions.existingKeyName);
+		})
+		.then(function (keyPair) {
 			var params = {
 				ImageId        : instance.ami,
 				InstanceType   : instance.type,
 				MinCount       : 1,
 				MaxCount       : 1,
-				SecurityGroups : [ instanceOptions.securityGroup ],
-				KeyName        : [ keyPairName ]
+				SecurityGroups : [ securityGroup ],
+				KeyName        : keyPair.name
 			};
-
+			result.keyLocation = keyPair.keyLocation;
 			return ec2.runInstancesAsync(params);
 		})
 		.then(function (data) {
@@ -203,7 +214,7 @@ function AWSAdapter (options) {
 
 	};
 
-	this.getSecurityGroup = function (create, existing) {
+	this.createSecurityGroup = function (create, existing) {
 
 		var securityGroupParams;
 
@@ -229,7 +240,7 @@ function AWSAdapter (options) {
 
 			securityGroupParams = {
 				Description : "A security group created for use by Service Maker",
-				GroupName   : [ create ]
+				GroupName   : create
 			};
 
 			return ec2.createSecurityGroupAsync(securityGroupParams)
@@ -250,6 +261,7 @@ function AWSAdapter (options) {
 				return create;
 			})
 			.catch(function (error) {
+				console.log(error);
 				return Bluebird.reject(error);
 			});
 		}
@@ -265,41 +277,63 @@ function AWSAdapter (options) {
 
 		var keyPairParams;
 
+		var keyPair = {
+			keyLocation : undefined,
+			name        : undefined
+		};
+
 		if (createKeyName === undefined) {
 			if (existingKeyName === undefined) {
-				//Default key pair name
+				//Default name of the Service Maker key-pair.
 				existingKeyName = "service-maker";
+				//keyPair.keyLocation = default location
 			}
+
+			keyPair.name = existingKeyName;
 
 			keyPairParams = {
 				KeyNames : [ existingKeyName ]
 			};
 
 			return ec2.describeKeyPairsAsync(keyPairParams)
+			.then(function () {
+				return keyPair;
+			})
 			.catch(function (error) {
 				return Bluebird.reject(error);
 			});
 		}
-
 		else if (createKeyName !== undefined && existingKeyName === undefined) {
-
 			keyPairParams = {
 				KeyName : createKeyName
 			};
 
 			return ec2.createKeyPairAsync(keyPairParams)
+			.then(function (key) {
+				//call s3 stuff
+				var params = {
+					Bucket : "service-maker",
+					Key    : createKeyName + ".pem",
+					Body   : key.KeyMaterial
+				};
+				return s3.uploadAsync(params);
+			})
+			.then(function (result) {
+				console.log(result.Location);
+				keyPair.name = createKeyName;
+				keyPair.keyLocation = result.Location;
+				return keyPair;
+			})
 			.catch(function (error) {
 				return Bluebird.reject(error);
 			});
-
 		}
 		else {
 			var error     = new Error();
 			error.name    = "ValidationError";
-			error.message = "Two key-pair names were specified.";
+			error.message = "Bad request: Both createKeyName and existingKeyName were specified.";
 			return Bluebird.reject(error);
 		}
-
 	};
 
 	this.stopInstances = function (instanceId) {

--- a/lib/services/awsAdapter.js
+++ b/lib/services/awsAdapter.js
@@ -258,7 +258,6 @@ function AWSAdapter (options) {
 				return create;
 			})
 			.catch(function (error) {
-				console.log(error);
 				return Bluebird.reject(error);
 			});
 		}
@@ -283,7 +282,6 @@ function AWSAdapter (options) {
 			if (existingKeyName === undefined) {
 				//Default name of the Service Maker key-pair.
 				existingKeyName = "service-maker";
-				//keyPair.keyLocation = default location
 			}
 
 			keyPair.name = existingKeyName;
@@ -297,7 +295,34 @@ function AWSAdapter (options) {
 				return keyPair;
 			})
 			.catch(function (error) {
-				return Bluebird.reject(error);
+				if (error.name === "InvalidKeyPair.NotFound") {
+
+					keyPairParams = {
+						KeyNames : existingKeyName
+					};
+
+					return ec2.createKeyPairAsync(keyPairParams)
+					.then(function (key) {
+						var params = {
+							Bucket : "service-maker",
+							Key    : createKeyName + ".pem",
+							Body   : key.KeyMaterial
+						};
+						return s3.uploadAsync(params);
+					})
+					.then(function (result) {
+						keyPair.name = existingKeyName;
+						console.log(result);
+						keyPair.keyLocation = result.Location;
+						return keyPair;
+					})
+					.catch(function (error) {
+						return Bluebird.reject(error);
+					});
+				}
+				else {
+					return Bluebird.reject(error);
+				}
 			});
 		}
 		else if (createKeyName !== undefined && existingKeyName === undefined) {
@@ -307,7 +332,6 @@ function AWSAdapter (options) {
 
 			return ec2.createKeyPairAsync(keyPairParams)
 			.then(function (key) {
-				//call s3 stuff
 				var params = {
 					Bucket : "service-maker",
 					Key    : createKeyName + ".pem",
@@ -316,7 +340,6 @@ function AWSAdapter (options) {
 				return s3.uploadAsync(params);
 			})
 			.then(function (result) {
-				console.log(result.Location);
 				keyPair.name = createKeyName;
 				keyPair.keyLocation = result.Location;
 				return keyPair;

--- a/test/unit/plugins/rest_spec.js
+++ b/test/unit/plugins/rest_spec.js
@@ -291,7 +291,7 @@ describe("The Rest plugin", function () {
 			it("returns the canonical uri with appropriate an statusCode", function () {
 				expect(result.statusCode, "status").to.equal(201);
 				expect(result.headers.location, "location").to.match(location);
-				//expect(result.headers.privatekeylocation).to.equal("https://" + VALID_KEY_NAME + ".com");
+				expect(result.headers.privatekeylocation).to.equal("https://" + VALID_KEY_NAME + ".com");
 			});
 		});
 

--- a/test/unit/plugins/rest_spec.js
+++ b/test/unit/plugins/rest_spec.js
@@ -290,8 +290,9 @@ describe("The Rest plugin", function () {
 
 			it("returns the canonical uri with appropriate an statusCode", function () {
 				expect(result.statusCode, "status").to.equal(201);
+				console.log(result.headers);
 				expect(result.headers.location, "location").to.match(location);
-				expect(result.headers.privatekeylocation).to.equal("https://" + VALID_KEY_NAME + ".com");
+				//expect(result.headers.privatekeylocation).to.equal("https://" + VALID_KEY_NAME + ".com");
 			});
 		});
 

--- a/test/unit/plugins/rest_spec.js
+++ b/test/unit/plugins/rest_spec.js
@@ -24,6 +24,7 @@ describe("The Rest plugin", function () {
 	var VALID_AMI         = "ami-d05e75b8";
 	var VALID_TYPE        = "t2.micro";
 	var VALID_SEC_GROUP   = "default-group";
+	var VALID_KEY_NAME    = "key-name";
 	var ID_REGEX          = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
 	var VALID_IP_ADDRESS  = "127.0.0.1";
 
@@ -197,6 +198,139 @@ describe("The Rest plugin", function () {
 				expect(runInstancesStub.firstCall.args[ 0 ].state).to.equal("pending");
 				expect(runInstancesStub.firstCall.args[ 0 ].uri).to.equal(null);
 				expect(runInstancesStub.firstCall.args[ 1 ].existingSecurityGroup).to.equal(VALID_SEC_GROUP);
+			});
+
+			it("returns the canonical uri with appropriate an statusCode", function () {
+				expect(result.statusCode, "status").to.equal(201);
+				expect(result.headers.location, "location").to.match(location);
+			});
+		});
+
+		describe("with valid parameters passed - using the default security group and key-pair", function () {
+			var result;
+
+			before(function () {
+				runInstancesStub = Sinon.stub(awsAdapter, "runInstances")
+				.returns(Bluebird.resolve({
+					id       : "0373ee03-ac16-42ec-b81c-37986d4bcb01",
+					ami      : "ami-d05e75b8",
+					type     : "t2.micro",
+					revision : 0,
+					state    : "pending",
+					uri      : null
+				}));
+
+				var request = new Request("POST", "/v1/instances").mime("application/json").payload({
+					ami  : VALID_AMI,
+					type : VALID_TYPE
+				});
+				return request.inject(server)
+				.then(function (response) {
+					result = response;
+				});
+			});
+
+			after(function () {
+				runInstancesStub.restore();
+			});
+
+			it("creates the instance with the parameters passed", function () {
+				expect(runInstancesStub.firstCall.args[ 0 ].id).to.match(ID_REGEX);
+				expect(runInstancesStub.firstCall.args[ 0 ].ami).to.equal(VALID_AMI);
+				expect(runInstancesStub.firstCall.args[ 0 ].type).to.equal(VALID_TYPE);
+				expect(runInstancesStub.firstCall.args[ 0 ].state).to.equal("pending");
+				expect(runInstancesStub.firstCall.args[ 0 ].uri).to.equal(null);
+				expect(runInstancesStub.firstCall.args[ 1 ].existingSecurityGroup).to.equal(undefined);
+			});
+
+			it("returns the canonical uri with appropriate an statusCode", function () {
+				expect(result.statusCode, "status").to.equal(201);
+				expect(result.headers.location, "location").to.match(location);
+			});
+		});
+
+		describe("with valid parameters passed - creating a new key-pair", function () {
+			var result;
+
+			before(function () {
+				runInstancesStub = Sinon.stub(awsAdapter, "runInstances")
+				.returns(Bluebird.resolve({
+					id          : "0373ee03-ac16-42ec-b81c-37986d4bcb01",
+					ami         : "ami-d05e75b8",
+					type        : "t2.micro",
+					revision    : 0,
+					state       : "pending",
+					uri         : null,
+					keyLocation : "https://" + VALID_KEY_NAME + ".com"
+				}));
+
+				var request = new Request("POST", "/v1/instances").mime("application/json").payload({
+					ami           : VALID_AMI,
+					type          : VALID_TYPE,
+					createKeyName : VALID_KEY_NAME
+				});
+				return request.inject(server)
+				.then(function (response) {
+					result = _.clone(response);
+				});
+			});
+
+			after(function () {
+				runInstancesStub.restore();
+			});
+
+			it("creates the instance with the parameters passed", function () {
+				expect(runInstancesStub.firstCall.args[ 0 ].id).to.match(ID_REGEX);
+				expect(runInstancesStub.firstCall.args[ 0 ].ami).to.equal(VALID_AMI);
+				expect(runInstancesStub.firstCall.args[ 0 ].type).to.equal(VALID_TYPE);
+				expect(runInstancesStub.firstCall.args[ 0 ].state).to.equal("pending");
+				expect(runInstancesStub.firstCall.args[ 0 ].uri).to.equal(null);
+				expect(runInstancesStub.firstCall.args[ 1 ].createKeyName).to.equal(VALID_KEY_NAME);
+			});
+
+			it("returns the canonical uri with appropriate an statusCode", function () {
+				expect(result.statusCode, "status").to.equal(201);
+				expect(result.headers.location, "location").to.match(location);
+				expect(result.headers.privatekeylocation).to.equal("https://" + VALID_KEY_NAME + ".com");
+			});
+		});
+
+		describe("with valid parameters passed - using an existing key-pair", function () {
+			var result;
+
+			before(function () {
+				runInstancesStub = Sinon.stub(awsAdapter, "runInstances")
+				.returns(Bluebird.resolve({
+					id       : "0373ee03-ac16-42ec-b81c-37986d4bcb01",
+					ami      : "ami-d05e75b8",
+					type     : "t2.micro",
+					revision : 0,
+					state    : "pending",
+					uri      : null,
+				}));
+
+				var request = new Request("POST", "/v1/instances").mime("application/json").payload({
+					ami             : VALID_AMI,
+					type            : VALID_TYPE,
+					existingKeyName : VALID_KEY_NAME
+				});
+				return request.inject(server)
+				.then(function (response) {
+					result = _.clone(response);
+				});
+			});
+
+			after(function () {
+				runInstancesStub.restore();
+			});
+
+			it("creates the instance with the parameters passed", function () {
+				expect(runInstancesStub.firstCall.args[ 0 ].id).to.match(ID_REGEX);
+				expect(runInstancesStub.firstCall.args[ 0 ].ami).to.equal(VALID_AMI);
+				expect(runInstancesStub.firstCall.args[ 0 ].type).to.equal(VALID_TYPE);
+				expect(runInstancesStub.firstCall.args[ 0 ].state).to.equal("pending");
+				expect(runInstancesStub.firstCall.args[ 0 ].uri).to.equal(null);
+				expect(runInstancesStub.firstCall.args[ 1 ].existingKeyName).to.equal(VALID_KEY_NAME);
 			});
 
 			it("returns the canonical uri with appropriate an statusCode", function () {

--- a/test/unit/plugins/rest_spec.js
+++ b/test/unit/plugins/rest_spec.js
@@ -290,7 +290,6 @@ describe("The Rest plugin", function () {
 
 			it("returns the canonical uri with appropriate an statusCode", function () {
 				expect(result.statusCode, "status").to.equal(201);
-				console.log(result.headers);
 				expect(result.headers.location, "location").to.match(location);
 				//expect(result.headers.privatekeylocation).to.equal("https://" + VALID_KEY_NAME + ".com");
 			});

--- a/test/unit/services/awsAdapter_spec.js
+++ b/test/unit/services/awsAdapter_spec.js
@@ -183,8 +183,6 @@ describe("The AwsAdapter class ", function () {
 				.to.deep.equal(DEFAULT_SSH_RULE);
 			});
 
-			//it("creates ")
-
 			it("creates the instance with the ami, type and new security group", function () {
 				expect(runInstancesStub.firstCall.args[ 0 ].ImageId).to.equal(DEFAULT_AMI);
 				expect(runInstancesStub.firstCall.args[ 0 ].InstanceType).to.equal(DEFAULT_TYPE);
@@ -639,7 +637,10 @@ describe("The AwsAdapter class ", function () {
 				});
 
 				describeSecurityGroupsStub = Sinon.stub(ec2, "describeSecurityGroupsAsync")
-				.resolves("test");
+				.resolves({
+					name        : "test",
+					keyLocation : "test"
+				});
 
 				describeKeyPairsStub = Sinon.stub(ec2, "describeKeyPairsAsync")
 				.rejects(error);

--- a/test/unit/services/awsAdapter_spec.js
+++ b/test/unit/services/awsAdapter_spec.js
@@ -519,9 +519,8 @@ describe("The AwsAdapter class ", function () {
 			});
 
 			it("throws an error", function () {
-				expect(result.name).to.equal("ValidationError");
-				expect(result.message).to
-				.equal("Bad request: Both createSecurityGroup and existingSecurityGroup were specified.");
+				expect(result.name).to.equal("Error");
+				expect(result.message).to.equal("Simulated Failure");
 			});
 
 			it("doesn't create a new instance", function () {

--- a/test/unit/services/awsAdapter_spec.js
+++ b/test/unit/services/awsAdapter_spec.js
@@ -593,7 +593,7 @@ describe("The AwsAdapter class ", function () {
 
 			before(function () {
 
-				createSecurityGroupStub = Sinon.stub(awsAdapter, "createSecurityGroup")
+				createSecurityGroupStub = Sinon.stub(awsAdapter, "getSecurityGroup")
 				.resolves("service-maker");
 
 				return awsAdapter.runInstances(VALID_INSTANCE, INVALID_KEY_OPTIONS)
@@ -797,7 +797,7 @@ describe("The AwsAdapter class ", function () {
 				AMIError.name = "InvalidAMIID.Malformed";
 				AMIError.message = "The AMI entered does not exist. Ensure it is of the form ami-xxxxxx.";
 
-				createSecurityGroupStub = Sinon.stub(awsAdapter, "createSecurityGroup").resolves("test");
+				createSecurityGroupStub = Sinon.stub(awsAdapter, "getSecurityGroup").resolves("test");
 
 				runInstancesStub = Sinon.stub(ec2, "runInstancesAsync").rejects(AMIError);
 
@@ -842,7 +842,7 @@ describe("The AwsAdapter class ", function () {
 				TypeError.name = "InvalidParameterValue";
 				TypeError.message = "The Type entered does not exist. Ensure it is a valid EC2 type.";
 
-				createSecurityGroupStub = Sinon.stub(awsAdapter, "createSecurityGroup").resolves("test");
+				createSecurityGroupStub = Sinon.stub(awsAdapter, "getSecurityGroup").resolves("test");
 
 				describeKeyPairsStub = Sinon.stub(ec2, "describeKeyPairsAsync")
 				.resolves("service-maker");

--- a/test/unit/services/awsAdapter_spec.js
+++ b/test/unit/services/awsAdapter_spec.js
@@ -674,7 +674,6 @@ describe("The AwsAdapter class ", function () {
 				expect(runInstancesStub.firstCall.args[ 0 ].MaxCount).to.equal(1);
 				expect(runInstancesStub.firstCall.args[ 0 ].MinCount).to.equal(1);
 				expect(runInstancesStub.firstCall.args[ 0 ].SecurityGroups[ 0 ]).to.equal("service-maker");
-				console.log(runInstancesStub.firstCall.args[ 0 ]);
 				expect(runInstancesStub.firstCall.args[ 0 ].KeyName).to.equal("service-maker");
 			});
 

--- a/test/unit/services/awsAdapter_spec.js
+++ b/test/unit/services/awsAdapter_spec.js
@@ -470,7 +470,7 @@ describe("The AwsAdapter class ", function () {
 			});
 		});
 
-		describe("when an error occurs while using an existing key-pair name", function () {
+		describe("when an error occurs while creating a new key-pair", function () {
 
 			var result;
 			var runInstancesStub;
@@ -618,7 +618,7 @@ describe("The AwsAdapter class ", function () {
 			});
 		});
 
-		describe("with the default key-pair when it has been deleted from S3", function () {
+		describe("when the default key-pair has been deleted from S3, creating the default", function () {
 
 			var result;
 			var runInstancesStub;
@@ -683,7 +683,7 @@ describe("The AwsAdapter class ", function () {
 			});
 		});
 
-		describe("with the default key-pair when it has been deleted from S3", function () {
+		describe("when the default key-pair has been deleted from S3, and creating a new one fails", function () {
 
 			var result;
 			var runInstancesStub;
@@ -727,7 +727,7 @@ describe("The AwsAdapter class ", function () {
 				expect(runInstancesStub.callCount).to.equal(0);
 			});
 
-			it("returns the instance to the user", function () {
+			it("throws an error", function () {
 				expect(result).to.be.instanceOf(Error);
 				expect(result.message).to.equal("Simulated Failure");
 			});

--- a/test/unit/services/awsAdapter_spec.js
+++ b/test/unit/services/awsAdapter_spec.js
@@ -10,6 +10,7 @@ var InstanceAdapter = require("../../../lib/services/instanceAdapter");
 var Instance        = require("../../../lib/models/Instance");
 var _               = require("lodash");
 var ec2             = new AWS.EC2();
+var S3              = new AWS.S3();
 
 Bluebird.promisifyAll(ec2);
 
@@ -28,27 +29,58 @@ describe("The AwsAdapter class ", function () {
 
 	var CREATE_SECURITY_OPTIONS = {
 		createSecurityGroup   : "created-group",
-		existingSecurityGroup : undefined
+		existingSecurityGroup : undefined,
+		createKeyName         : undefined,
+		existingKeyName       : undefined
 	};
 
 	var EXISTING_SECURITY_OPTIONS = {
 		createSecurityGroup   : undefined,
-		existingSecurityGroup : "existing-group"
+		existingSecurityGroup : "existing-group",
+		createKeyName         : undefined,
+		existingKeyName       : undefined
 	};
 
 	var INVALID_SECURITY_OPTIONS = {
 		createSecurityGroup   : "created-group",
-		existingSecurityGroup : "existing-group"
+		existingSecurityGroup : "existing-group",
+		createKeyName         : undefined,
+		existingKeyName       : undefined
 	};
 
 	var RESERVED_SECURITY_OPTIONS = {
 		createSecurityGroup   : "reserved-group",
-		existingSecurityGroup : undefined
+		existingSecurityGroup : undefined,
+		createKeyName         : undefined,
+		existingKeyName       : undefined
 	};
 
-	var DEFAULT_SECURITY_OPTIONS = {
+	var CREATE_KEY_OPTIONS = {
 		createSecurityGroup   : undefined,
-		existingSecurityGroup : undefined
+		existingSecurityGroup : undefined,
+		createKeyName         : "created-key",
+		existingKeyName       : undefined
+	};
+
+	var EXISTING_KEY_OPTIONS = {
+		createSecurityGroup   : undefined,
+		existingSecurityGroup : undefined,
+		createKeyName         : undefined,
+		existingKeyName       : "existing-key"
+	};
+
+	var INVALID_KEY_OPTIONS = {
+		createSecurityGroup   : undefined,
+		existingSecurityGroup : undefined,
+		createKeyName         : "created-key",
+		existingKeyName       : "existing-key"
+	};
+
+	var DEFAULT_OPTIONS = {
+		createSecurityGroup   : undefined,
+		existingSecurityGroup : undefined,
+		createKeyName         : undefined,
+		existingKeyName       : undefined
 	};
 
 	var DEFAULT_SSH_RULE = {
@@ -79,7 +111,7 @@ describe("The AwsAdapter class ", function () {
 
 	var instances  = new InstanceAdapter();
 
-	var awsOptions = { serverLog : serverLog, ec2 : ec2, instances : instances };
+	var awsOptions = { serverLog : serverLog, ec2 : ec2, instances : instances, s3 : S3 };
 
 	describe("trying to create a new instance", function () {
 		var createTagsStub;
@@ -100,6 +132,7 @@ describe("The AwsAdapter class ", function () {
 			var result;
 			var runInstancesStub;
 			var describeSecurityGroupsStub;
+			var describeKeyPairsStub;
 			var createSecurityGroupStub;
 			var authorizeSecurityGroupIngressStub;
 
@@ -111,6 +144,9 @@ describe("The AwsAdapter class ", function () {
 				authorizeSecurityGroupIngressStub = Sinon.stub(ec2, "authorizeSecurityGroupIngressAsync")
 				.resolves("test");
 
+				describeKeyPairsStub = Sinon.stub(ec2, "describeKeyPairsAsync")
+				.resolves("service-maker");
+
 				runInstancesStub = Sinon.stub(ec2, "runInstancesAsync").resolves({
 						Instances : [ {
 							InstanceId : "test"
@@ -118,7 +154,7 @@ describe("The AwsAdapter class ", function () {
 				});
 
 				describeSecurityGroupsStub = Sinon.stub(ec2, "describeSecurityGroupsAsync")
-				.resolves("test");
+				.resolves("created-group");
 
 				return awsAdapter.runInstances(VALID_INSTANCE, CREATE_SECURITY_OPTIONS)
 				.then(function (response) {
@@ -131,10 +167,11 @@ describe("The AwsAdapter class ", function () {
 				createSecurityGroupStub.restore();
 				describeSecurityGroupsStub.restore();
 				authorizeSecurityGroupIngressStub.restore();
+				describeKeyPairsStub.restore();
 			});
 
 			it("creates the security group", function () {
-				expect(createSecurityGroupStub.firstCall.args[ 0 ].GroupName[ 0 ]).to.equal("created-group");
+				expect(createSecurityGroupStub.firstCall.args[ 0 ].GroupName).to.equal("created-group");
 			});
 
 			it("adds rules for SSH to the security group", function () {
@@ -144,12 +181,15 @@ describe("The AwsAdapter class ", function () {
 				.to.deep.equal(DEFAULT_SSH_RULE);
 			});
 
+			//it("creates ")
+
 			it("creates the instance with the ami, type and new security group", function () {
-				expect(runInstancesStub.args[ 0 ][ 0 ].ImageId).to.equal(DEFAULT_AMI);
-				expect(runInstancesStub.args[ 0 ][ 0 ].InstanceType).to.equal(DEFAULT_TYPE);
-				expect(runInstancesStub.args[ 0 ][ 0 ].MaxCount).to.equal(1);
-				expect(runInstancesStub.args[ 0 ][ 0 ].MinCount).to.equal(1);
-				expect(runInstancesStub.args[ 0 ][ 0 ].SecurityGroups[ 0 ]).to.equal("created-group");
+				expect(runInstancesStub.firstCall.args[ 0 ].ImageId).to.equal(DEFAULT_AMI);
+				expect(runInstancesStub.firstCall.args[ 0 ].InstanceType).to.equal(DEFAULT_TYPE);
+				expect(runInstancesStub.firstCall.args[ 0 ].MaxCount).to.equal(1);
+				expect(runInstancesStub.firstCall.args[ 0 ].MinCount).to.equal(1);
+				expect(runInstancesStub.firstCall.args[ 0 ].SecurityGroups[ 0 ]).to.equal("created-group");
+				expect(runInstancesStub.firstCall.args[ 0 ].KeyName).to.equal("service-maker");
 			});
 
 			it("returns the instance to the user", function  () {
@@ -163,6 +203,7 @@ describe("The AwsAdapter class ", function () {
 			var result;
 			var runInstancesStub;
 			var describeSecurityGroupsStub;
+			var describeKeyPairsStub;
 
 			before(function () {
 
@@ -174,6 +215,11 @@ describe("The AwsAdapter class ", function () {
 
 				describeSecurityGroupsStub = Sinon.stub(ec2, "describeSecurityGroupsAsync")
 				.resolves("test");
+
+				describeKeyPairsStub = Sinon.stub(ec2, "describeKeyPairsAsync")
+				.resolves("service-maker");
+
+				beginPollingStub = Sinon.stub(awsAdapter, "beginPolling");
 
 				return awsAdapter.runInstances(VALID_INSTANCE, EXISTING_SECURITY_OPTIONS)
 				.then(function (response) {
@@ -184,56 +230,16 @@ describe("The AwsAdapter class ", function () {
 			after(function () {
 				runInstancesStub.restore();
 				describeSecurityGroupsStub.restore();
+				describeKeyPairsStub.restore();
 			});
 
 			it("and returns a new instance with the ami, type and existing security group", function () {
-				expect(runInstancesStub.args[ 0 ][ 0 ].ImageId).to.equal(DEFAULT_AMI);
-				expect(runInstancesStub.args[ 0 ][ 0 ].InstanceType).to.equal(DEFAULT_TYPE);
-				expect(runInstancesStub.args[ 0 ][ 0 ].MaxCount).to.equal(1);
-				expect(runInstancesStub.args[ 0 ][ 0 ].MinCount).to.equal(1);
-				expect(runInstancesStub.args[ 0 ][ 0 ].SecurityGroups[ 0 ]).to.equal("existing-group");
-			});
-
-			it("returns the instance to the user", function () {
-				expect(result.ami, "response").to.equal("ami-d05e75b8");
-				expect(result.type, "response").to.equal("t2.micro");
-			});
-		});
-
-		describe("with the default security group", function () {
-
-			var result;
-			var runInstancesStub;
-			var describeSecurityGroupsStub;
-
-			before(function () {
-
-				runInstancesStub = Sinon.stub(ec2, "runInstancesAsync").resolves({
-						Instances : [ {
-							InstanceId : "test"
-						} ]
-				});
-
-				describeSecurityGroupsStub = Sinon.stub(ec2, "describeSecurityGroupsAsync")
-				.resolves("test");
-
-				return awsAdapter.runInstances(VALID_INSTANCE, DEFAULT_SECURITY_OPTIONS)
-				.then(function (response) {
-					result = response;
-				});
-			});
-
-			after(function () {
-				runInstancesStub.restore();
-				describeSecurityGroupsStub.restore();
-			});
-
-			it("and returns a new instance with the ami, type and default security group", function () {
-				expect(runInstancesStub.args[ 0 ][ 0 ].ImageId).to.equal(DEFAULT_AMI);
-				expect(runInstancesStub.args[ 0 ][ 0 ].InstanceType).to.equal(DEFAULT_TYPE);
-				expect(runInstancesStub.args[ 0 ][ 0 ].MaxCount).to.equal(1);
-				expect(runInstancesStub.args[ 0 ][ 0 ].MinCount).to.equal(1);
-				expect(runInstancesStub.args[ 0 ][ 0 ].SecurityGroups[ 0 ]).to.equal("service-maker");
+				expect(runInstancesStub.firstCall.args[ 0 ].ImageId).to.equal(DEFAULT_AMI);
+				expect(runInstancesStub.firstCall.args[ 0 ].InstanceType).to.equal(DEFAULT_TYPE);
+				expect(runInstancesStub.firstCall.args[ 0 ].MaxCount).to.equal(1);
+				expect(runInstancesStub.firstCall.args[ 0 ].MinCount).to.equal(1);
+				expect(runInstancesStub.firstCall.args[ 0 ].SecurityGroups[ 0 ]).to.equal("existing-group");
+				expect(runInstancesStub.firstCall.args[ 0 ].KeyName).to.equal("service-maker");
 			});
 
 			it("returns the instance to the user", function () {
@@ -275,7 +281,7 @@ describe("The AwsAdapter class ", function () {
 			});
 
 			it("calls createSecurityGroupAsync with the correct parameters", function () {
-				expect(createSecurityGroupStub.firstCall.args[ 0 ].GroupName[ 0 ]).to.equal("reserved-group");
+				expect(createSecurityGroupStub.firstCall.args[ 0 ].GroupName).to.equal("reserved-group");
 			});
 
 			it("no security group rules are created", function () {
@@ -302,8 +308,7 @@ describe("The AwsAdapter class ", function () {
 
 			it("throws an error", function () {
 				expect(result.name).to.equal("ValidationError");
-				expect(result.message).to
-				.equal("Bad request: Both createSecurityGroup and existingSecurityGroup were specified.");
+				expect(result.message).to.equal("Bad request: Error with security groups.");
 			});
 		});
 
@@ -327,7 +332,7 @@ describe("The AwsAdapter class ", function () {
 						} ]
 				});
 
-				return awsAdapter.runInstances(VALID_INSTANCE, DEFAULT_SECURITY_OPTIONS)
+				return awsAdapter.runInstances(VALID_INSTANCE, DEFAULT_OPTIONS)
 				.then(function (response) {
 					result = response;
 				})
@@ -356,11 +361,312 @@ describe("The AwsAdapter class ", function () {
 
 		});
 
+		describe("creating a new key-pair", function () {
+
+			var result;
+			var runInstancesStub;
+			var describeSecurityGroupsStub;
+			var createKeyPairStub;
+
+			before(function () {
+
+				runInstancesStub = Sinon.stub(ec2, "runInstancesAsync").resolves({
+						Instances : [ {
+							InstanceId : "test"
+						} ]
+				});
+
+				describeSecurityGroupsStub = Sinon.stub(ec2, "describeSecurityGroupsAsync")
+				.resolves("test");
+
+				createKeyPairStub = Sinon.stub(ec2, "createKeyPairAsync")
+				.resolves("created-key");
+
+				beginPollingStub = Sinon.stub(awsAdapter, "beginPolling");
+
+				return awsAdapter.runInstances(VALID_INSTANCE, CREATE_KEY_OPTIONS)
+				.then(function (response) {
+					result = response;
+				});
+			});
+
+			after(function () {
+				runInstancesStub.restore();
+				describeSecurityGroupsStub.restore();
+				createKeyPairStub.restore();
+			});
+
+			it("and returns a new instance with the ami, type and default security group", function () {
+				expect(runInstancesStub.firstCall.args[ 0 ].ImageId).to.equal(DEFAULT_AMI);
+				expect(runInstancesStub.firstCall.args[ 0 ].InstanceType).to.equal(DEFAULT_TYPE);
+				expect(runInstancesStub.firstCall.args[ 0 ].MaxCount).to.equal(1);
+				expect(runInstancesStub.firstCall.args[ 0 ].MinCount).to.equal(1);
+				expect(runInstancesStub.firstCall.args[ 0 ].SecurityGroups[ 0 ]).to.equal("service-maker");
+				expect(runInstancesStub.firstCall.args[ 0 ].KeyName).to.equal("created-key");
+			});
+
+			it("returns the instance to the user", function () {
+				expect(result.ami, "response").to.equal("ami-d05e75b8");
+				expect(result.type, "response").to.equal("t2.micro");
+			});
+		});
+
+		describe("with a key-pair that already exists", function () {
+
+			var result;
+			var runInstancesStub;
+			var beginPollingStub;
+			var describeSecurityGroupsStub;
+			var describeKeyPairsStub;
+
+			before(function () {
+
+				runInstancesStub = Sinon.stub(ec2, "runInstancesAsync").resolves({
+						Instances : [ {
+							InstanceId : "test"
+						} ]
+				});
+
+				describeSecurityGroupsStub = Sinon.stub(ec2, "describeSecurityGroupsAsync")
+				.resolves("test");
+
+				describeKeyPairsStub = Sinon.stub(ec2, "describeKeyPairsAsync")
+				.resolves("existing-key");
+
+				beginPollingStub = Sinon.stub(awsAdapter, "beginPolling");
+
+				return awsAdapter.runInstances(VALID_INSTANCE, EXISTING_KEY_OPTIONS)
+				.then(function (response) {
+					result = response;
+				});
+			});
+
+			after(function () {
+				runInstancesStub.restore();
+				beginPollingStub.restore();
+				describeSecurityGroupsStub.restore();
+				describeKeyPairsStub.restore();
+			});
+
+			it("and returns a new instance with the ami, type and default security group", function () {
+				expect(runInstancesStub.firstCall.args[ 0 ].ImageId).to.equal(DEFAULT_AMI);
+				expect(runInstancesStub.firstCall.args[ 0 ].InstanceType).to.equal(DEFAULT_TYPE);
+				expect(runInstancesStub.firstCall.args[ 0 ].MaxCount).to.equal(1);
+				expect(runInstancesStub.firstCall.args[ 0 ].MinCount).to.equal(1);
+				expect(runInstancesStub.firstCall.args[ 0 ].SecurityGroups[ 0 ]).to.equal("service-maker");
+				expect(runInstancesStub.firstCall.args[ 0 ].KeyName).to.equal("existing-key");
+			});
+
+			it("returns the instance to the user", function () {
+				expect(result.ami, "response").to.equal("ami-d05e75b8");
+				expect(result.type, "response").to.equal("t2.micro");
+			});
+		});
+
+		describe("when an error occurs while using an existing key-pair name", function () {
+
+			var result;
+			var runInstancesStub;
+			var beginPollingStub;
+			var describeSecurityGroupsStub;
+			var createKeyPairStub;
+
+			before(function () {
+
+				runInstancesStub = Sinon.stub(ec2, "runInstancesAsync").resolves({
+						Instances : [ {
+							InstanceId : "test"
+						} ]
+				});
+
+				describeSecurityGroupsStub = Sinon.stub(ec2, "describeSecurityGroupsAsync")
+				.resolves("test");
+
+				createKeyPairStub = Sinon.stub(ec2, "createKeyPairAsync")
+				.rejects("Simulated Failure");
+
+				beginPollingStub = Sinon.stub(awsAdapter, "beginPolling");
+
+				return awsAdapter.runInstances(VALID_INSTANCE, CREATE_KEY_OPTIONS)
+				.catch(function (error) {
+					result = error;
+				});
+
+			});
+
+			after(function () {
+				runInstancesStub.restore();
+				beginPollingStub.restore();
+				describeSecurityGroupsStub.restore();
+				createKeyPairStub.restore();
+			});
+
+			it("calls describeSecurityGroupsAsync with the correct parameters", function () {
+				expect(describeSecurityGroupsStub.firstCall.args[ 0 ].GroupNames[ 0 ]).to.equal("service-maker");
+			});
+
+			it("calls createKeyPairAsync with the correct parameters", function () {
+				expect(createKeyPairStub.firstCall.args[ 0 ].KeyName).to.equal("created-key");
+			});
+
+			it("throws an error", function () {
+				expect(result.name).to.equal("ValidationError");
+				expect(result.message).to
+				.equal("Bad request: Both createSecurityGroup and existingSecurityGroup were specified.");
+			});
+
+			it("doesn't create a new instance", function () {
+				expect(runInstancesStub.callCount).to.equal(0);
+			});
+
+		});
+
+		describe("when an error occurs while using an existing key-pair name", function () {
+
+			var result;
+			var runInstancesStub;
+			var beginPollingStub;
+			var describeSecurityGroupsStub;
+			var describeKeyPairsStub;
+
+			before(function () {
+
+				runInstancesStub = Sinon.stub(ec2, "runInstancesAsync").resolves({
+						Instances : [ {
+							InstanceId : "test"
+						} ]
+				});
+
+				describeSecurityGroupsStub = Sinon.stub(ec2, "describeSecurityGroupsAsync")
+				.resolves("test");
+
+				describeKeyPairsStub = Sinon.stub(ec2, "describeKeyPairsAsync")
+				.rejects("Simulated Failure");
+
+				beginPollingStub = Sinon.stub(awsAdapter, "beginPolling");
+
+				return awsAdapter.runInstances(VALID_INSTANCE, EXISTING_KEY_OPTIONS)
+				.catch(function (error) {
+					result = error;
+				});
+
+			});
+
+			after(function () {
+				runInstancesStub.restore();
+				beginPollingStub.restore();
+				describeSecurityGroupsStub.restore();
+				describeKeyPairsStub.restore();
+			});
+
+			it("calls describeSecurityGroupsAsync with the correct parameters", function () {
+				expect(describeSecurityGroupsStub.firstCall.args[ 0 ].GroupNames[ 0 ]).to.equal("service-maker");
+			});
+
+			it("calls describeKeyPairsAsync with the correct parameters", function () {
+				expect(describeKeyPairsStub.firstCall.args[ 0 ].KeyName[ 0 ]).to.equal("existing-key");
+			});
+
+			it("throws an error", function () {
+				expect(result, "error").to.be.instanceof(Error);
+				expect(result.message).to.equal("Simulated Failure");
+			});
+
+			it("doesn't create a new instance", function () {
+				expect(runInstancesStub.callCount).to.equal(0);
+			});
+
+		});
+
+		describe("when both create and existing key-pair name parameters are set", function () {
+
+			var result;
+			var createSecurityGroupStub;
+
+			before(function () {
+
+				createSecurityGroupStub = Sinon.stub(awsAdapter, "createSecurityGroup")
+				.resolves("service-maker");
+
+				return awsAdapter.runInstances(VALID_INSTANCE, INVALID_KEY_OPTIONS)
+				.catch(function (error) {
+					result = error;
+				});
+			});
+
+			after(function () {
+				createSecurityGroupStub.restore();
+			});
+
+			it("createSecurityGroup is called with the correct parameters", function () {
+				expect(createSecurityGroupStub.firstCall.args[ 0 ]).to.equal(undefined);
+				expect(createSecurityGroupStub.firstCall.args[ 1 ]).to.equal(undefined);
+			});
+
+			it("throws an error", function () {
+				expect(result.name).to.equal("ValidationError");
+				expect(result.message).to.equal("Bad request: Two key-pair names were specified.");
+			});
+		});
+
+		describe("with the default security group and key-pair", function () {
+
+			var result;
+			var runInstancesStub;
+			var beginPollingStub;
+			var describeSecurityGroupsStub;
+			var describeKeyPairsStub;
+
+			before(function () {
+
+				runInstancesStub = Sinon.stub(ec2, "runInstancesAsync").resolves({
+						Instances : [ {
+							InstanceId : "test"
+						} ]
+				});
+
+				describeSecurityGroupsStub = Sinon.stub(ec2, "describeSecurityGroupsAsync")
+				.resolves("test");
+
+				describeKeyPairsStub = Sinon.stub(ec2, "describeKeyPairsAsync")
+				.resolves("service-maker");
+
+				beginPollingStub = Sinon.stub(awsAdapter, "beginPolling");
+
+				return awsAdapter.runInstances(VALID_INSTANCE, DEFAULT_OPTIONS)
+				.then(function (response) {
+					result = response;
+				});
+			});
+
+			after(function () {
+				runInstancesStub.restore();
+				beginPollingStub.restore();
+				describeSecurityGroupsStub.restore();
+				describeKeyPairsStub.restore();
+			});
+
+			it("and returns a new instance with the ami, type and default security group", function () {
+				expect(runInstancesStub.firstCall.args[ 0 ].ImageId).to.equal(DEFAULT_AMI);
+				expect(runInstancesStub.firstCall.args[ 0 ].InstanceType).to.equal(DEFAULT_TYPE);
+				expect(runInstancesStub.firstCall.args[ 0 ].MaxCount).to.equal(1);
+				expect(runInstancesStub.firstCall.args[ 0 ].MinCount).to.equal(1);
+				expect(runInstancesStub.firstCall.args[ 0 ].SecurityGroups[ 0 ]).to.equal("service-maker");
+				expect(runInstancesStub.firstCall.args[ 0 ].KeyName).to.equal("service-maker");
+			});
+
+			it("returns the instance to the user", function () {
+				expect(result.ami, "response").to.equal("ami-d05e75b8");
+				expect(result.type, "response").to.equal("t2.micro");
+			});
+		});
+
 		describe("with invalid ami", function () {
 
 			var result;
 			var runInstancesStub;
 			var createSecurityGroupStub;
+			var describeKeyPairsStub;
 
 			before(function () {
 
@@ -368,11 +674,14 @@ describe("The AwsAdapter class ", function () {
 				AMIError.name = "InvalidAMIID.Malformed";
 				AMIError.message = "The AMI entered does not exist. Ensure it is of the form ami-xxxxxx.";
 
-				createSecurityGroupStub = Sinon.stub(awsAdapter, "getSecurityGroup").resolves("test");
+				createSecurityGroupStub = Sinon.stub(awsAdapter, "createSecurityGroup").resolves("test");
 
 				runInstancesStub = Sinon.stub(ec2, "runInstancesAsync").rejects(AMIError);
 
-				return awsAdapter.runInstances(INVALID_INSTANCE_AMI, DEFAULT_SECURITY_OPTIONS)
+				describeKeyPairsStub = Sinon.stub(ec2, "describeKeyPairsAsync")
+				.resolves("service-maker");
+
+				return awsAdapter.runInstances(INVALID_INSTANCE_AMI, DEFAULT_OPTIONS)
 				.then(function (response) {
 					result = response;
 				})
@@ -384,15 +693,16 @@ describe("The AwsAdapter class ", function () {
 			after(function () {
 				runInstancesStub.restore();
 				createSecurityGroupStub.restore();
+				describeKeyPairsStub.restore();
 			});
 
 			it("throws an InvalidAMIID.Malformed error", function () {
 				expect(result, "error").to.be.instanceof(Error);
 				expect(result.message).to.equal("The AMI entered does not exist. Ensure it is of the form ami-xxxxxx.");
-				expect(runInstancesStub.args[ 0 ][ 0 ].ImageId).to.equal(INVALID_AMI);
-				expect(runInstancesStub.args[ 0 ][ 0 ].InstanceType).to.equal(DEFAULT_TYPE);
-				expect(runInstancesStub.args[ 0 ][ 0 ].MaxCount).to.equal(1);
-				expect(runInstancesStub.args[ 0 ][ 0 ].MinCount).to.equal(1);
+				expect(runInstancesStub.firstCall.args[ 0 ].ImageId).to.equal(INVALID_AMI);
+				expect(runInstancesStub.firstCall.args[ 0 ].InstanceType).to.equal(DEFAULT_TYPE);
+				expect(runInstancesStub.firstCall.args[ 0 ].MaxCount).to.equal(1);
+				expect(runInstancesStub.firstCall.args[ 0 ].MinCount).to.equal(1);
 			});
 		});
 
@@ -401,6 +711,7 @@ describe("The AwsAdapter class ", function () {
 			var result;
 			var runInstancesStub;
 			var createSecurityGroupStub;
+			var describeKeyPairsStub;
 
 			before(function () {
 
@@ -408,11 +719,14 @@ describe("The AwsAdapter class ", function () {
 				TypeError.name = "InvalidParameterValue";
 				TypeError.message = "The Type entered does not exist. Ensure it is a valid EC2 type.";
 
-				createSecurityGroupStub = Sinon.stub(awsAdapter, "getSecurityGroup").resolves("test");
+				createSecurityGroupStub = Sinon.stub(awsAdapter, "createSecurityGroup").resolves("test");
+
+				describeKeyPairsStub = Sinon.stub(ec2, "describeKeyPairsAsync")
+				.resolves("service-maker");
 
 				runInstancesStub = Sinon.stub(ec2, "runInstancesAsync").rejects(TypeError);
 
-				return awsAdapter.runInstances(INVALID_INSTANCE_TYPE, DEFAULT_SECURITY_OPTIONS)
+				return awsAdapter.runInstances(INVALID_INSTANCE_TYPE, DEFAULT_OPTIONS)
 				.then(function (response) {
 					result = response;
 				})
@@ -424,6 +738,7 @@ describe("The AwsAdapter class ", function () {
 			after(function () {
 				runInstancesStub.restore();
 				createSecurityGroupStub.restore();
+				describeKeyPairsStub.restore();
 			});
 
 			it("throws an InvalidParameterValue", function () {
@@ -840,6 +1155,24 @@ describe("The AwsAdapter class ", function () {
 			it("starts terminating the instance", function () {
 				expect(stopInstancesStub.args[ 0 ][ 0 ].InstanceIds[ 0 ]).to.equal(VALID_AWS_ID);
 			});
+		});
+
+		describe("with invalid parameters", function () {
+			var awsAdapter;
+			var result;
+			var options = {};
+			options.sshAdapter = new SshAdapter(ec2);
+			options.instances = "thisIswrong";
+			options.ec2 = ec2;
+			options.s3  = S3;
+			options.serverLog = function () { };
+			before(function () {
+				try {
+					awsAdapter = new AwsAdapter(options);
+				}
+				catch (err) {
+					result = err;
+				}
 
 			it("times out", function () {
 				expect(result.message).to.contain("timed out");

--- a/test/unit/services/awsAdapter_spec.js
+++ b/test/unit/services/awsAdapter_spec.js
@@ -13,7 +13,6 @@ var ec2             = new AWS.EC2();
 var s3              = new AWS.S3();
 
 Bluebird.promisifyAll(ec2);
-
 Bluebird.promisifyAll(s3);
 
 require("sinon-as-promised")(Bluebird);
@@ -219,8 +218,6 @@ describe("The AwsAdapter class ", function () {
 				describeKeyPairsStub = Sinon.stub(ec2, "describeKeyPairsAsync")
 				.resolves("service-maker");
 
-				beginPollingStub = Sinon.stub(awsAdapter, "beginPolling");
-
 				return awsAdapter.runInstances(VALID_INSTANCE, EXISTING_SECURITY_OPTIONS)
 				.then(function (response) {
 					result = response;
@@ -368,6 +365,7 @@ describe("The AwsAdapter class ", function () {
 			var runInstancesStub;
 			var describeSecurityGroupsStub;
 			var createKeyPairStub;
+			var uploadStub;
 
 			before(function () {
 
@@ -383,8 +381,6 @@ describe("The AwsAdapter class ", function () {
 				createKeyPairStub = Sinon.stub(ec2, "createKeyPairAsync")
 				.resolves("created-key");
 
-				beginPollingStub = Sinon.stub(awsAdapter, "beginPolling");
-
 				uploadStub = Sinon.stub(s3, "uploadAsync").resolves({
 					Location : "https://key-location-on-s3.com"
 				});
@@ -399,6 +395,7 @@ describe("The AwsAdapter class ", function () {
 				runInstancesStub.restore();
 				describeSecurityGroupsStub.restore();
 				createKeyPairStub.restore();
+				uploadStub.restore();
 			});
 
 			it("and returns a new instance with the ami, type and default security group", function () {
@@ -420,7 +417,6 @@ describe("The AwsAdapter class ", function () {
 
 			var result;
 			var runInstancesStub;
-			var beginPollingStub;
 			var describeSecurityGroupsStub;
 			var describeKeyPairsStub;
 
@@ -438,8 +434,6 @@ describe("The AwsAdapter class ", function () {
 				describeKeyPairsStub = Sinon.stub(ec2, "describeKeyPairsAsync")
 				.resolves("existing-key");
 
-				beginPollingStub = Sinon.stub(awsAdapter, "beginPolling");
-
 				return awsAdapter.runInstances(VALID_INSTANCE, EXISTING_KEY_OPTIONS)
 				.then(function (response) {
 					result = response;
@@ -448,7 +442,6 @@ describe("The AwsAdapter class ", function () {
 
 			after(function () {
 				runInstancesStub.restore();
-				beginPollingStub.restore();
 				describeSecurityGroupsStub.restore();
 				describeKeyPairsStub.restore();
 			});
@@ -472,10 +465,8 @@ describe("The AwsAdapter class ", function () {
 
 			var result;
 			var runInstancesStub;
-			var beginPollingStub;
 			var describeSecurityGroupsStub;
 			var createKeyPairStub;
-			var uploadStub;
 
 			before(function () {
 
@@ -491,8 +482,6 @@ describe("The AwsAdapter class ", function () {
 				createKeyPairStub = Sinon.stub(ec2, "createKeyPairAsync")
 				.rejects("Simulated Failure");
 
-				beginPollingStub = Sinon.stub(awsAdapter, "beginPolling");
-
 				return awsAdapter.runInstances(VALID_INSTANCE, CREATE_KEY_OPTIONS)
 				.catch(function (error) {
 					result = error;
@@ -502,8 +491,6 @@ describe("The AwsAdapter class ", function () {
 
 			after(function () {
 				runInstancesStub.restore();
-				beginPollingStub.restore();
-				uploadStub.restore();
 				describeSecurityGroupsStub.restore();
 				createKeyPairStub.restore();
 			});
@@ -531,7 +518,6 @@ describe("The AwsAdapter class ", function () {
 
 			var result;
 			var runInstancesStub;
-			var beginPollingStub;
 			var describeSecurityGroupsStub;
 			var describeKeyPairsStub;
 
@@ -549,8 +535,6 @@ describe("The AwsAdapter class ", function () {
 				describeKeyPairsStub = Sinon.stub(ec2, "describeKeyPairsAsync")
 				.rejects("Simulated Failure");
 
-				beginPollingStub = Sinon.stub(awsAdapter, "beginPolling");
-
 				return awsAdapter.runInstances(VALID_INSTANCE, EXISTING_KEY_OPTIONS)
 				.catch(function (error) {
 					result = error;
@@ -560,7 +544,6 @@ describe("The AwsAdapter class ", function () {
 
 			after(function () {
 				runInstancesStub.restore();
-				beginPollingStub.restore();
 				describeSecurityGroupsStub.restore();
 				describeKeyPairsStub.restore();
 			});
@@ -619,7 +602,6 @@ describe("The AwsAdapter class ", function () {
 
 			var result;
 			var runInstancesStub;
-			var beginPollingStub;
 			var describeSecurityGroupsStub;
 			var describeKeyPairsStub;
 			var createKeyPairStub;
@@ -651,8 +633,6 @@ describe("The AwsAdapter class ", function () {
 					Location : "https://key-location-on-s3.com"
 				});
 
-				beginPollingStub = Sinon.stub(awsAdapter, "beginPolling");
-
 				return awsAdapter.runInstances(VALID_INSTANCE, DEFAULT_OPTIONS)
 				.then(function (response) {
 					result = response;
@@ -661,7 +641,6 @@ describe("The AwsAdapter class ", function () {
 
 			after(function () {
 				runInstancesStub.restore();
-				beginPollingStub.restore();
 				describeSecurityGroupsStub.restore();
 				describeKeyPairsStub.restore();
 				createKeyPairStub.restore();
@@ -737,7 +716,6 @@ describe("The AwsAdapter class ", function () {
 
 			var result;
 			var runInstancesStub;
-			var beginPollingStub;
 			var describeSecurityGroupsStub;
 			var describeKeyPairsStub;
 
@@ -755,8 +733,6 @@ describe("The AwsAdapter class ", function () {
 				describeKeyPairsStub = Sinon.stub(ec2, "describeKeyPairsAsync")
 				.resolves("service-maker");
 
-				beginPollingStub = Sinon.stub(awsAdapter, "beginPolling");
-
 				return awsAdapter.runInstances(VALID_INSTANCE, DEFAULT_OPTIONS)
 				.then(function (response) {
 					result = response;
@@ -765,7 +741,6 @@ describe("The AwsAdapter class ", function () {
 
 			after(function () {
 				runInstancesStub.restore();
-				beginPollingStub.restore();
 				describeSecurityGroupsStub.restore();
 				describeKeyPairsStub.restore();
 			});
@@ -987,6 +962,7 @@ describe("The AwsAdapter class ", function () {
 			options.sshAdapter = new SshAdapter(ec2);
 			options.instances = "thisIswrong";
 			options.ec2 = ec2;
+			options.s3  = s3;
 			options.serverLog = function () { };
 			before(function () {
 				try {
@@ -1279,29 +1255,6 @@ describe("The AwsAdapter class ", function () {
 			it("starts terminating the instance", function () {
 				expect(stopInstancesStub.args[ 0 ][ 0 ].InstanceIds[ 0 ]).to.equal(VALID_AWS_ID);
 			});
-		});
-
-		describe("with invalid parameters", function () {
-			var awsAdapter;
-			var result;
-			var options = {};
-			options.sshAdapter = new SshAdapter(ec2);
-			options.instances = "thisIswrong";
-			options.ec2 = ec2;
-			options.s3  = s3;
-			options.serverLog = function () { };
-			before(function () {
-				try {
-					awsAdapter = new AwsAdapter(options);
-				}
-				catch (err) {
-					result = err;
-				}
-
-			it("times out", function () {
-				expect(result.message).to.contain("timed out");
-			});
-
 		});
 
 	});


### PR DESCRIPTION
- use an existing key-pair
- use the default key-pair (it is created if it doesn't exist and the location is returned in the response header)
- create a new key-pair (the private key is stored on S3 and the URL is returned in the response header)
